### PR TITLE
Restrict OAuth Scopes

### DIFF
--- a/syncademic_app/lib/authorization/authorization_service.dart
+++ b/syncademic_app/lib/authorization/authorization_service.dart
@@ -27,7 +27,7 @@ class MockAuthorizationService implements AuthorizationService {
   Future<String?> get accessToken => Future.value(null);
 }
 
-final _scopes = [CalendarApi.calendarScope, CalendarApi.calendarEventsScope];
+final _scopes = [CalendarApi.calendarScope];
 
 class GoogleAuthorizationService implements AuthorizationService {
   final GoogleSignIn _googleSignIn;


### PR DESCRIPTION
Before, both the following scopes were requested to the user : 

- `https://www.googleapis.com/auth/calendar`
- `https://www.googleapis.com/auth/calendar.events`

But `calendar.events` is included in `calendar`. 

So we only request `calendar`