### PR TITLE
Implement backend authorization flow

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -8,7 +8,11 @@ service cloud.firestore {
     }
   	
     match /users/{userId}/syncProfiles/{syncProfileId}{
-    allow create, read, update, delete: if request.auth != null && request.auth.uid == userId;
+      allow create, read, update, delete: if request.auth != null && request.auth.uid == userId;
+    }
+
+    match /backendAuthorizations/{document=**} {
+      allow read, write: if false;
     }
   }
 }

--- a/functions/synchronizer/synchronizer/middleware/insa_middleware.py
+++ b/functions/synchronizer/synchronizer/middleware/insa_middleware.py
@@ -53,7 +53,7 @@ def ExamPrettifier(events: List[Event]) -> List[Event]:
 
 
 def _add_exam_emoji(event: Event) -> Event:
-    """
+    r"""
     SUMMARY:IF:4:S2::AFQL:EV::IF-4-S2-GR-CM
     LOCATION:501.212 - TD 212\,501.329 - TD 329\,501.331 - TD 331\,5020002 -
     Pierre-Gilles de Gennes

--- a/syncademic_app/lib/authorization/authorization_service.dart
+++ b/syncademic_app/lib/authorization/authorization_service.dart
@@ -13,6 +13,13 @@ abstract class AuthorizationService {
   Future<bool> authorize();
   Future<http.Client?> get authorizedClient;
   Future<String?> get accessToken;
+
+  /// Returns the user ID of the currently authorized user.
+  ///
+  /// Note that this ID may not match the ID of the currently signed-in user.
+  /// This is because a single user can establish multiple sync profiles,
+  /// each potentially associated with a different calendar service.
+  Future<String?> get userId;
   Future<String?> getAuthorizationCode();
 }
 
@@ -31,6 +38,9 @@ class MockAuthorizationService implements AuthorizationService {
 
   @override
   Future<String?> getAuthorizationCode() => Future.value('mocked_auth_code');
+
+  @override
+  Future<String?> get userId => Future.value('mocked_user_id');
 }
 
 final _scopes = [CalendarApi.calendarScope];
@@ -82,4 +92,7 @@ class GoogleAuthorizationService implements AuthorizationService {
   @override
   Future<http.Client?> get authorizedClient =>
       _googleSignIn.authenticatedClient();
+
+  @override
+  Future<String?> get userId async => _currentUser?.id;
 }

--- a/syncademic_app/lib/authorization/backend_authorization_service.dart
+++ b/syncademic_app/lib/authorization/backend_authorization_service.dart
@@ -2,16 +2,17 @@ import 'dart:developer';
 
 import 'package:cloud_functions/cloud_functions.dart';
 import 'package:get_it/get_it.dart';
+
 import 'authorization_service.dart';
 
 abstract class BackendAuthorizationService {
-  Future<void> authorizeBackend(String syncProfileId);
+  Future<void> authorizeBackend();
 }
 
 class FirebaseBackendAuthorizationService
     implements BackendAuthorizationService {
   @override
-  Future<void> authorizeBackend(String syncProfileId) async {
+  Future<void> authorizeBackend() async {
     log("Authorizing the backend using Firebase");
 
     final authCode =
@@ -27,7 +28,6 @@ class FirebaseBackendAuthorizationService
     try {
       await FirebaseFunctions.instance.httpsCallable('authorize_backend').call({
         'authCode': authCode,
-        'syncProfileId': syncProfileId,
       });
     } on FirebaseFunctionsException catch (e) {
       log('Error authorizing backend: ${e.code}, ${e.details}, ${e.message}');

--- a/syncademic_app/lib/main.dart
+++ b/syncademic_app/lib/main.dart
@@ -4,25 +4,25 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:get_it/get_it.dart';
 import 'package:go_router/go_router.dart';
-import 'authorization/backend_authorization_service.dart';
-import 'screens/new_sync_profile/cubit/new_sync_profile_cubit.dart';
-import 'screens/landing_page.dart';
-import 'screens/sync_profile/cubit/sync_profile_cubit.dart';
-import 'services/sync_profile_service.dart';
 
 import 'authentication/cubit/auth_cubit.dart';
 import 'authorization/authorization_service.dart';
+import 'authorization/backend_authorization_service.dart';
 import 'firebase_options.dart';
 import 'repositories/firestore_sync_profile_repository.dart';
 import 'repositories/sync_profile_repository.dart';
 import 'screens/account/account_page.dart';
+import 'screens/landing_page.dart';
+import 'screens/new_sync_profile/cubit/new_sync_profile_cubit.dart';
 import 'screens/new_sync_profile/new_sync_profile_page.dart';
 import 'screens/new_sync_profile/target_calendar_selector/target_calendar_selector_cubit.dart';
+import 'screens/sync_profile/cubit/sync_profile_cubit.dart';
 import 'screens/sync_profile/sync_profile_page.dart';
 import 'services/account_service.dart';
 import 'services/auth_service.dart';
 import 'services/firebase_auth_service.dart';
 import 'services/firestore_account_service.dart';
+import 'services/sync_profile_service.dart';
 import 'widgets/sync_profiles_list.dart';
 
 void main() async {

--- a/syncademic_app/lib/models/target_calendar.dart
+++ b/syncademic_app/lib/models/target_calendar.dart
@@ -7,9 +7,29 @@ part 'target_calendar.freezed.dart';
 @freezed
 class TargetCalendar with _$TargetCalendar {
   const factory TargetCalendar({
+    /// The unique identifier for the calendar.
+    ///
+    /// For Google Calendar, this is the ID of the calendar provided by Google.
     required ID id,
+
+    /// The title of the calendar, as provided by the calendar service.
     required String title,
-    String? accessToken,
+
+    /// The unique identifier for the user account that owns the calendar.
+    ///
+    /// This identifier represents the specific user account associated with the calendar,
+    /// and it varies depending on the calendar service being used.
+    ///
+    /// For Google Calendar:
+    /// - The `accountOwnerUserId` is the ID of the Google Account that owns the calendar.
+    ///
+    /// For Microsoft Outlook:
+    /// - The `accountOwnerUserId` is the ID of the Microsoft Outlook account that owns the calendar.
+    ///
+    /// Note: The `accountOwnerUserId` is different from the `id` property, which represents the unique identifier
+    /// of the calendar itself. It is also different from the user ID that is logged in to the Syncademic app,
+    /// as a user can have multiple accounts on multiple calendar services.
+    required String accountOwnerUserId,
     bool? createdBySyncademic,
   }) = _TargetCalendar;
 }

--- a/syncademic_app/lib/models/target_calendar.freezed.dart
+++ b/syncademic_app/lib/models/target_calendar.freezed.dart
@@ -16,9 +16,29 @@ final _privateConstructorUsedError = UnsupportedError(
 
 /// @nodoc
 mixin _$TargetCalendar {
+  /// The unique identifier for the calendar.
+  ///
+  /// For Google Calendar, this is the ID of the calendar provided by Google.
   ID get id => throw _privateConstructorUsedError;
+
+  /// The title of the calendar, as provided by the calendar service.
   String get title => throw _privateConstructorUsedError;
-  String? get accessToken => throw _privateConstructorUsedError;
+
+  /// The unique identifier for the user account that owns the calendar.
+  ///
+  /// This identifier represents the specific user account associated with the calendar,
+  /// and it varies depending on the calendar service being used.
+  ///
+  /// For Google Calendar:
+  /// - The `accountOwnerUserId` is the ID of the Google Account that owns the calendar.
+  ///
+  /// For Microsoft Outlook:
+  /// - The `accountOwnerUserId` is the ID of the Microsoft Outlook account that owns the calendar.
+  ///
+  /// Note: The `accountOwnerUserId` is different from the `id` property, which represents the unique identifier
+  /// of the calendar itself. It is also different from the user ID that is logged in to the Syncademic app,
+  /// as a user can have multiple accounts on multiple calendar services.
+  String get accountOwnerUserId => throw _privateConstructorUsedError;
   bool? get createdBySyncademic => throw _privateConstructorUsedError;
 
   @JsonKey(ignore: true)
@@ -33,7 +53,10 @@ abstract class $TargetCalendarCopyWith<$Res> {
       _$TargetCalendarCopyWithImpl<$Res, TargetCalendar>;
   @useResult
   $Res call(
-      {ID id, String title, String? accessToken, bool? createdBySyncademic});
+      {ID id,
+      String title,
+      String accountOwnerUserId,
+      bool? createdBySyncademic});
 }
 
 /// @nodoc
@@ -51,7 +74,7 @@ class _$TargetCalendarCopyWithImpl<$Res, $Val extends TargetCalendar>
   $Res call({
     Object? id = null,
     Object? title = null,
-    Object? accessToken = freezed,
+    Object? accountOwnerUserId = null,
     Object? createdBySyncademic = freezed,
   }) {
     return _then(_value.copyWith(
@@ -63,10 +86,10 @@ class _$TargetCalendarCopyWithImpl<$Res, $Val extends TargetCalendar>
           ? _value.title
           : title // ignore: cast_nullable_to_non_nullable
               as String,
-      accessToken: freezed == accessToken
-          ? _value.accessToken
-          : accessToken // ignore: cast_nullable_to_non_nullable
-              as String?,
+      accountOwnerUserId: null == accountOwnerUserId
+          ? _value.accountOwnerUserId
+          : accountOwnerUserId // ignore: cast_nullable_to_non_nullable
+              as String,
       createdBySyncademic: freezed == createdBySyncademic
           ? _value.createdBySyncademic
           : createdBySyncademic // ignore: cast_nullable_to_non_nullable
@@ -84,7 +107,10 @@ abstract class _$$TargetCalendarImplCopyWith<$Res>
   @override
   @useResult
   $Res call(
-      {ID id, String title, String? accessToken, bool? createdBySyncademic});
+      {ID id,
+      String title,
+      String accountOwnerUserId,
+      bool? createdBySyncademic});
 }
 
 /// @nodoc
@@ -100,7 +126,7 @@ class __$$TargetCalendarImplCopyWithImpl<$Res>
   $Res call({
     Object? id = null,
     Object? title = null,
-    Object? accessToken = freezed,
+    Object? accountOwnerUserId = null,
     Object? createdBySyncademic = freezed,
   }) {
     return _then(_$TargetCalendarImpl(
@@ -112,10 +138,10 @@ class __$$TargetCalendarImplCopyWithImpl<$Res>
           ? _value.title
           : title // ignore: cast_nullable_to_non_nullable
               as String,
-      accessToken: freezed == accessToken
-          ? _value.accessToken
-          : accessToken // ignore: cast_nullable_to_non_nullable
-              as String?,
+      accountOwnerUserId: null == accountOwnerUserId
+          ? _value.accountOwnerUserId
+          : accountOwnerUserId // ignore: cast_nullable_to_non_nullable
+              as String,
       createdBySyncademic: freezed == createdBySyncademic
           ? _value.createdBySyncademic
           : createdBySyncademic // ignore: cast_nullable_to_non_nullable
@@ -130,21 +156,41 @@ class _$TargetCalendarImpl implements _TargetCalendar {
   const _$TargetCalendarImpl(
       {required this.id,
       required this.title,
-      this.accessToken,
+      required this.accountOwnerUserId,
       this.createdBySyncademic});
 
+  /// The unique identifier for the calendar.
+  ///
+  /// For Google Calendar, this is the ID of the calendar provided by Google.
   @override
   final ID id;
+
+  /// The title of the calendar, as provided by the calendar service.
   @override
   final String title;
+
+  /// The unique identifier for the user account that owns the calendar.
+  ///
+  /// This identifier represents the specific user account associated with the calendar,
+  /// and it varies depending on the calendar service being used.
+  ///
+  /// For Google Calendar:
+  /// - The `accountOwnerUserId` is the ID of the Google Account that owns the calendar.
+  ///
+  /// For Microsoft Outlook:
+  /// - The `accountOwnerUserId` is the ID of the Microsoft Outlook account that owns the calendar.
+  ///
+  /// Note: The `accountOwnerUserId` is different from the `id` property, which represents the unique identifier
+  /// of the calendar itself. It is also different from the user ID that is logged in to the Syncademic app,
+  /// as a user can have multiple accounts on multiple calendar services.
   @override
-  final String? accessToken;
+  final String accountOwnerUserId;
   @override
   final bool? createdBySyncademic;
 
   @override
   String toString() {
-    return 'TargetCalendar(id: $id, title: $title, accessToken: $accessToken, createdBySyncademic: $createdBySyncademic)';
+    return 'TargetCalendar(id: $id, title: $title, accountOwnerUserId: $accountOwnerUserId, createdBySyncademic: $createdBySyncademic)';
   }
 
   @override
@@ -154,15 +200,15 @@ class _$TargetCalendarImpl implements _TargetCalendar {
             other is _$TargetCalendarImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.title, title) || other.title == title) &&
-            (identical(other.accessToken, accessToken) ||
-                other.accessToken == accessToken) &&
+            (identical(other.accountOwnerUserId, accountOwnerUserId) ||
+                other.accountOwnerUserId == accountOwnerUserId) &&
             (identical(other.createdBySyncademic, createdBySyncademic) ||
                 other.createdBySyncademic == createdBySyncademic));
   }
 
   @override
-  int get hashCode =>
-      Object.hash(runtimeType, id, title, accessToken, createdBySyncademic);
+  int get hashCode => Object.hash(
+      runtimeType, id, title, accountOwnerUserId, createdBySyncademic);
 
   @JsonKey(ignore: true)
   @override
@@ -176,15 +222,36 @@ abstract class _TargetCalendar implements TargetCalendar {
   const factory _TargetCalendar(
       {required final ID id,
       required final String title,
-      final String? accessToken,
+      required final String accountOwnerUserId,
       final bool? createdBySyncademic}) = _$TargetCalendarImpl;
 
   @override
+
+  /// The unique identifier for the calendar.
+  ///
+  /// For Google Calendar, this is the ID of the calendar provided by Google.
   ID get id;
   @override
+
+  /// The title of the calendar, as provided by the calendar service.
   String get title;
   @override
-  String? get accessToken;
+
+  /// The unique identifier for the user account that owns the calendar.
+  ///
+  /// This identifier represents the specific user account associated with the calendar,
+  /// and it varies depending on the calendar service being used.
+  ///
+  /// For Google Calendar:
+  /// - The `accountOwnerUserId` is the ID of the Google Account that owns the calendar.
+  ///
+  /// For Microsoft Outlook:
+  /// - The `accountOwnerUserId` is the ID of the Microsoft Outlook account that owns the calendar.
+  ///
+  /// Note: The `accountOwnerUserId` is different from the `id` property, which represents the unique identifier
+  /// of the calendar itself. It is also different from the user ID that is logged in to the Syncademic app,
+  /// as a user can have multiple accounts on multiple calendar services.
+  String get accountOwnerUserId;
   @override
   bool? get createdBySyncademic;
   @override

--- a/syncademic_app/lib/repositories/firestore_sync_profile_repository.dart
+++ b/syncademic_app/lib/repositories/firestore_sync_profile_repository.dart
@@ -22,7 +22,7 @@ class FirestoreSyncProfileRepository implements SyncProfileRepository {
       'targetCalendar': {
         'id': syncProfile.targetCalendar.id.value,
         'title': syncProfile.targetCalendar.title,
-        'accessToken': syncProfile.targetCalendar.accessToken,
+        'accountOwnerUserId': syncProfile.targetCalendar.accountOwnerUserId,
       },
       'status': {'type': 'notStarted'}
     });
@@ -62,6 +62,7 @@ class FirestoreSyncProfileRepository implements SyncProfileRepository {
     final targetCalendar = TargetCalendar(
       id: ID.fromString(data['targetCalendar']['id']),
       title: data['targetCalendar']['title'],
+      accountOwnerUserId: data['targetCalendar']['accountOwnerUserId'],
     );
 
     final timestamp = data['lastSuccessfulSync'] as Timestamp?;

--- a/syncademic_app/lib/repositories/google_target_calendar_repository.dart
+++ b/syncademic_app/lib/repositories/google_target_calendar_repository.dart
@@ -13,11 +13,13 @@ import 'target_calendar_repository.dart';
 
 class GoogleTargetCalendarRepository implements TargetCalendarRepository {
   final CalendarApi _client;
-  final String? accessToken;
+  final String _accountOwnerUserId;
 
-  GoogleTargetCalendarRepository(
-      {required http.Client authorizedClient, this.accessToken})
-      : _client = CalendarApi(authorizedClient);
+  GoogleTargetCalendarRepository({
+    required http.Client authorizedClient,
+    required accountOwnerUserId,
+  })  : _client = CalendarApi(authorizedClient),
+        _accountOwnerUserId = accountOwnerUserId;
 
   @override
   Future<List<TargetCalendar>> getCalendars() async {
@@ -25,8 +27,8 @@ class GoogleTargetCalendarRepository implements TargetCalendarRepository {
     return calendarList.items!
         .map((calendarListEntry) => TargetCalendar(
               id: ID.fromString(calendarListEntry.id!),
-              title: calendarListEntry.summary!,
-              accessToken: accessToken,
+              title: calendarListEntry.summary ?? 'Unnamed calendar',
+              accountOwnerUserId: _accountOwnerUserId,
             ))
         .toList();
   }

--- a/syncademic_app/lib/repositories/sync_profile_repository.dart
+++ b/syncademic_app/lib/repositories/sync_profile_repository.dart
@@ -66,6 +66,7 @@ class MockSyncProfileRepository implements SyncProfileRepository {
     final targetCalendar = TargetCalendar(
       id: ID.fromString('target-google-calendar-${id.value}'),
       title: 'Calendar ${id.value}',
+      accountOwnerUserId: 'accountOwnerUserId',
     );
 
     int seconds = Random().nextInt(60);

--- a/syncademic_app/lib/repositories/sync_profile_repository.dart
+++ b/syncademic_app/lib/repositories/sync_profile_repository.dart
@@ -1,11 +1,10 @@
 import 'dart:async';
 import 'dart:math';
 
-import '../models/sync_profile_status.dart';
-
 import '../models/id.dart';
 import '../models/schedule_source.dart';
 import '../models/sync_profile.dart';
+import '../models/sync_profile_status.dart';
 import '../models/target_calendar.dart';
 
 abstract class SyncProfileRepository {

--- a/syncademic_app/lib/repositories/target_calendar_repository.dart
+++ b/syncademic_app/lib/repositories/target_calendar_repository.dart
@@ -8,8 +8,11 @@ abstract class TargetCalendarRepository {
 class MockTargetCalendarRepository implements TargetCalendarRepository {
   @override
   Future<List<TargetCalendar>> getCalendars() async => List.generate(
-      10,
-      (index) => TargetCalendar(
+        10,
+        (index) => TargetCalendar(
           id: ID.fromString('target-google-calendar-$index'),
-          title: 'Calendar $index'));
+          title: 'Calendar $index',
+          accountOwnerUserId: 'accountOwnerUserId',
+        ),
+      );
 }

--- a/syncademic_app/lib/screens/new_sync_profile/cubit/new_sync_profile_cubit.dart
+++ b/syncademic_app/lib/screens/new_sync_profile/cubit/new_sync_profile_cubit.dart
@@ -2,6 +2,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:get_it/get_it.dart';
 import 'package:quiver/strings.dart';
+import '../../../authorization/backend_authorization_service.dart';
 import '../../../models/id.dart';
 import '../../../models/schedule_source.dart';
 import '../../../models/sync_profile.dart';
@@ -54,8 +55,28 @@ class NewSyncProfileCubit extends Cubit<NewSyncProfileState> {
     emit(state.copyWith(targetCalendar: calendar));
   }
 
-  void backendAuthorizationChanged(String backendAuthorization) {
-    emit(state.copyWith(backendAuthorization: backendAuthorization));
+  void authorizeBackend() async {
+    emit(state.copyWith(
+        isAuthorizingBackend: true,
+        backendAuthorizationError: null,
+        hasAuthorizedBackend: false));
+
+    try {
+      await GetIt.I<BackendAuthorizationService>().authorizeBackend();
+    } catch (e) {
+      emit(state.copyWith(
+        isAuthorizingBackend: false,
+        hasAuthorizedBackend: false,
+        backendAuthorizationError: e.toString(),
+      ));
+      return;
+    }
+
+    emit(state.copyWith(
+      isAuthorizingBackend: false,
+      hasAuthorizedBackend: true,
+      backendAuthorizationError: null,
+    ));
   }
 
   void next() {

--- a/syncademic_app/lib/screens/new_sync_profile/cubit/new_sync_profile_cubit.freezed.dart
+++ b/syncademic_app/lib/screens/new_sync_profile/cubit/new_sync_profile_cubit.freezed.dart
@@ -22,7 +22,9 @@ mixin _$NewSyncProfileState {
   String get url => throw _privateConstructorUsedError;
   String? get urlError => throw _privateConstructorUsedError;
   TargetCalendar? get targetCalendar => throw _privateConstructorUsedError;
-  String? get backendAuthorization => throw _privateConstructorUsedError;
+  bool get isAuthorizingBackend => throw _privateConstructorUsedError;
+  bool get hasAuthorizedBackend => throw _privateConstructorUsedError;
+  String? get backendAuthorizationError => throw _privateConstructorUsedError;
   bool get isSubmitting => throw _privateConstructorUsedError;
   String? get submitError => throw _privateConstructorUsedError;
   bool get submittedSuccessfully => throw _privateConstructorUsedError;
@@ -45,7 +47,9 @@ abstract class $NewSyncProfileStateCopyWith<$Res> {
       String url,
       String? urlError,
       TargetCalendar? targetCalendar,
-      String? backendAuthorization,
+      bool isAuthorizingBackend,
+      bool hasAuthorizedBackend,
+      String? backendAuthorizationError,
       bool isSubmitting,
       String? submitError,
       bool submittedSuccessfully});
@@ -72,7 +76,9 @@ class _$NewSyncProfileStateCopyWithImpl<$Res, $Val extends NewSyncProfileState>
     Object? url = null,
     Object? urlError = freezed,
     Object? targetCalendar = freezed,
-    Object? backendAuthorization = freezed,
+    Object? isAuthorizingBackend = null,
+    Object? hasAuthorizedBackend = null,
+    Object? backendAuthorizationError = freezed,
     Object? isSubmitting = null,
     Object? submitError = freezed,
     Object? submittedSuccessfully = null,
@@ -102,9 +108,17 @@ class _$NewSyncProfileStateCopyWithImpl<$Res, $Val extends NewSyncProfileState>
           ? _value.targetCalendar
           : targetCalendar // ignore: cast_nullable_to_non_nullable
               as TargetCalendar?,
-      backendAuthorization: freezed == backendAuthorization
-          ? _value.backendAuthorization
-          : backendAuthorization // ignore: cast_nullable_to_non_nullable
+      isAuthorizingBackend: null == isAuthorizingBackend
+          ? _value.isAuthorizingBackend
+          : isAuthorizingBackend // ignore: cast_nullable_to_non_nullable
+              as bool,
+      hasAuthorizedBackend: null == hasAuthorizedBackend
+          ? _value.hasAuthorizedBackend
+          : hasAuthorizedBackend // ignore: cast_nullable_to_non_nullable
+              as bool,
+      backendAuthorizationError: freezed == backendAuthorizationError
+          ? _value.backendAuthorizationError
+          : backendAuthorizationError // ignore: cast_nullable_to_non_nullable
               as String?,
       isSubmitting: null == isSubmitting
           ? _value.isSubmitting
@@ -149,7 +163,9 @@ abstract class _$$NewSyncProfileStateImplCopyWith<$Res>
       String url,
       String? urlError,
       TargetCalendar? targetCalendar,
-      String? backendAuthorization,
+      bool isAuthorizingBackend,
+      bool hasAuthorizedBackend,
+      String? backendAuthorizationError,
       bool isSubmitting,
       String? submitError,
       bool submittedSuccessfully});
@@ -175,7 +191,9 @@ class __$$NewSyncProfileStateImplCopyWithImpl<$Res>
     Object? url = null,
     Object? urlError = freezed,
     Object? targetCalendar = freezed,
-    Object? backendAuthorization = freezed,
+    Object? isAuthorizingBackend = null,
+    Object? hasAuthorizedBackend = null,
+    Object? backendAuthorizationError = freezed,
     Object? isSubmitting = null,
     Object? submitError = freezed,
     Object? submittedSuccessfully = null,
@@ -205,9 +223,17 @@ class __$$NewSyncProfileStateImplCopyWithImpl<$Res>
           ? _value.targetCalendar
           : targetCalendar // ignore: cast_nullable_to_non_nullable
               as TargetCalendar?,
-      backendAuthorization: freezed == backendAuthorization
-          ? _value.backendAuthorization
-          : backendAuthorization // ignore: cast_nullable_to_non_nullable
+      isAuthorizingBackend: null == isAuthorizingBackend
+          ? _value.isAuthorizingBackend
+          : isAuthorizingBackend // ignore: cast_nullable_to_non_nullable
+              as bool,
+      hasAuthorizedBackend: null == hasAuthorizedBackend
+          ? _value.hasAuthorizedBackend
+          : hasAuthorizedBackend // ignore: cast_nullable_to_non_nullable
+              as bool,
+      backendAuthorizationError: freezed == backendAuthorizationError
+          ? _value.backendAuthorizationError
+          : backendAuthorizationError // ignore: cast_nullable_to_non_nullable
               as String?,
       isSubmitting: null == isSubmitting
           ? _value.isSubmitting
@@ -235,7 +261,9 @@ class _$NewSyncProfileStateImpl extends _NewSyncProfileState {
       this.url = '',
       this.urlError,
       this.targetCalendar,
-      this.backendAuthorization,
+      this.isAuthorizingBackend = false,
+      this.hasAuthorizedBackend = false,
+      this.backendAuthorizationError,
       this.isSubmitting = false,
       this.submitError,
       this.submittedSuccessfully = false})
@@ -257,7 +285,13 @@ class _$NewSyncProfileStateImpl extends _NewSyncProfileState {
   @override
   final TargetCalendar? targetCalendar;
   @override
-  final String? backendAuthorization;
+  @JsonKey()
+  final bool isAuthorizingBackend;
+  @override
+  @JsonKey()
+  final bool hasAuthorizedBackend;
+  @override
+  final String? backendAuthorizationError;
   @override
   @JsonKey()
   final bool isSubmitting;
@@ -269,7 +303,7 @@ class _$NewSyncProfileStateImpl extends _NewSyncProfileState {
 
   @override
   String toString() {
-    return 'NewSyncProfileState(currentStep: $currentStep, title: $title, titleError: $titleError, url: $url, urlError: $urlError, targetCalendar: $targetCalendar, backendAuthorization: $backendAuthorization, isSubmitting: $isSubmitting, submitError: $submitError, submittedSuccessfully: $submittedSuccessfully)';
+    return 'NewSyncProfileState(currentStep: $currentStep, title: $title, titleError: $titleError, url: $url, urlError: $urlError, targetCalendar: $targetCalendar, isAuthorizingBackend: $isAuthorizingBackend, hasAuthorizedBackend: $hasAuthorizedBackend, backendAuthorizationError: $backendAuthorizationError, isSubmitting: $isSubmitting, submitError: $submitError, submittedSuccessfully: $submittedSuccessfully)';
   }
 
   @override
@@ -287,8 +321,13 @@ class _$NewSyncProfileStateImpl extends _NewSyncProfileState {
                 other.urlError == urlError) &&
             (identical(other.targetCalendar, targetCalendar) ||
                 other.targetCalendar == targetCalendar) &&
-            (identical(other.backendAuthorization, backendAuthorization) ||
-                other.backendAuthorization == backendAuthorization) &&
+            (identical(other.isAuthorizingBackend, isAuthorizingBackend) ||
+                other.isAuthorizingBackend == isAuthorizingBackend) &&
+            (identical(other.hasAuthorizedBackend, hasAuthorizedBackend) ||
+                other.hasAuthorizedBackend == hasAuthorizedBackend) &&
+            (identical(other.backendAuthorizationError,
+                    backendAuthorizationError) ||
+                other.backendAuthorizationError == backendAuthorizationError) &&
             (identical(other.isSubmitting, isSubmitting) ||
                 other.isSubmitting == isSubmitting) &&
             (identical(other.submitError, submitError) ||
@@ -306,7 +345,9 @@ class _$NewSyncProfileStateImpl extends _NewSyncProfileState {
       url,
       urlError,
       targetCalendar,
-      backendAuthorization,
+      isAuthorizingBackend,
+      hasAuthorizedBackend,
+      backendAuthorizationError,
       isSubmitting,
       submitError,
       submittedSuccessfully);
@@ -327,7 +368,9 @@ abstract class _NewSyncProfileState extends NewSyncProfileState {
       final String url,
       final String? urlError,
       final TargetCalendar? targetCalendar,
-      final String? backendAuthorization,
+      final bool isAuthorizingBackend,
+      final bool hasAuthorizedBackend,
+      final String? backendAuthorizationError,
       final bool isSubmitting,
       final String? submitError,
       final bool submittedSuccessfully}) = _$NewSyncProfileStateImpl;
@@ -346,7 +389,11 @@ abstract class _NewSyncProfileState extends NewSyncProfileState {
   @override
   TargetCalendar? get targetCalendar;
   @override
-  String? get backendAuthorization;
+  bool get isAuthorizingBackend;
+  @override
+  bool get hasAuthorizedBackend;
+  @override
+  String? get backendAuthorizationError;
   @override
   bool get isSubmitting;
   @override

--- a/syncademic_app/lib/screens/new_sync_profile/cubit/new_sync_profile_state.dart
+++ b/syncademic_app/lib/screens/new_sync_profile/cubit/new_sync_profile_state.dart
@@ -9,7 +9,9 @@ class NewSyncProfileState with _$NewSyncProfileState {
     @Default('') String url,
     String? urlError,
     TargetCalendar? targetCalendar,
-    String? backendAuthorization,
+    @Default(false) bool isAuthorizingBackend,
+    @Default(false) bool hasAuthorizedBackend,
+    String? backendAuthorizationError,
     @Default(false) bool isSubmitting,
     String? submitError,
     @Default(false) bool submittedSuccessfully,
@@ -18,20 +20,24 @@ class NewSyncProfileState with _$NewSyncProfileState {
   const NewSyncProfileState._();
 
   bool get canContinue {
+    // Step 0: Title
     if (currentStep == 0) {
       return titleError == null && !isBlank(title);
     }
 
+    // Step 1: URL
     if (currentStep == 1) {
       return urlError == null && !isBlank(url);
     }
 
+    // Step 2: Target calendar
     if (currentStep == 2) {
       return targetCalendar != null;
     }
 
+    // Step 3: Authorize backend
     if (currentStep == 3) {
-      return true; //TODO
+      return hasAuthorizedBackend;
     }
 
     return false;

--- a/syncademic_app/lib/screens/new_sync_profile/target_calendar_selector/target_calendar_selector_cubit.dart
+++ b/syncademic_app/lib/screens/new_sync_profile/target_calendar_selector/target_calendar_selector_cubit.dart
@@ -16,7 +16,9 @@ class TargetCalendarSelectorCubit extends Cubit<TargetCalendarSelectorState> {
 
   Future<void> authorize() async {
     final authorizationService = GetIt.I<AuthorizationService>();
+
     emit(state.copyWith(authorizationStatus: AuthorizationStatus.authorizing));
+
     final isAuthorized = await authorizationService.authorize();
 
     if (!isAuthorized) {
@@ -43,7 +45,7 @@ class TargetCalendarSelectorCubit extends Cubit<TargetCalendarSelectorState> {
 
     final calendars = await GoogleTargetCalendarRepository(
       authorizedClient: authorizedClient,
-      accessToken: accessToken,
+      accountOwnerUserId: await authorizationService.userId,
     ).getCalendars();
 
     emit(state.copyWith(calendars: calendars));

--- a/syncademic_app/lib/screens/new_sync_profile/target_calendar_selector/target_calendar_selector_cubit.dart
+++ b/syncademic_app/lib/screens/new_sync_profile/target_calendar_selector/target_calendar_selector_cubit.dart
@@ -3,12 +3,13 @@ import 'dart:async';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:get_it/get_it.dart';
-import '../../../repositories/google_target_calendar_repository.dart';
-import '../../../models/target_calendar.dart';
-import '../../../authorization/authorization_service.dart';
 
-part 'target_calendar_selector_state.dart';
+import '../../../authorization/authorization_service.dart';
+import '../../../models/target_calendar.dart';
+import '../../../repositories/google_target_calendar_repository.dart';
+
 part 'target_calendar_selector_cubit.freezed.dart';
+part 'target_calendar_selector_state.dart';
 
 class TargetCalendarSelectorCubit extends Cubit<TargetCalendarSelectorState> {
   TargetCalendarSelectorCubit() : super(const TargetCalendarSelectorState());

--- a/syncademic_app/lib/screens/sync_profile/cubit/sync_profile_cubit.dart
+++ b/syncademic_app/lib/screens/sync_profile/cubit/sync_profile_cubit.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:get_it/get_it.dart';
+import 'package:syncademic_app/authorization/backend_authorization_service.dart';
 import '../../../models/id.dart';
 import '../../../models/sync_profile.dart';
 import '../../../services/sync_profile_service.dart';
@@ -25,5 +26,6 @@ class SyncProfileCubit extends Cubit<SyncProfileState> {
   Future<void> requestSync() =>
       GetIt.I<SyncProfileService>().requestSync(syncProfileId);
 
-  Future<void> authorizeBackend() => throw UnimplementedError();
+  Future<void> authorizeBackend() =>
+      GetIt.I<BackendAuthorizationService>().authorizeBackend();
 }

--- a/syncademic_app/lib/screens/sync_profile/cubit/sync_profile_cubit.dart
+++ b/syncademic_app/lib/screens/sync_profile/cubit/sync_profile_cubit.dart
@@ -1,7 +1,6 @@
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:get_it/get_it.dart';
-import '../../../authorization/backend_authorization_service.dart';
 import '../../../models/id.dart';
 import '../../../models/sync_profile.dart';
 import '../../../services/sync_profile_service.dart';
@@ -26,6 +25,5 @@ class SyncProfileCubit extends Cubit<SyncProfileState> {
   Future<void> requestSync() =>
       GetIt.I<SyncProfileService>().requestSync(syncProfileId);
 
-  Future<void> authorizeBackend() =>
-      GetIt.I<BackendAuthorizationService>().authorizeBackend(syncProfileId);
+  Future<void> authorizeBackend() => throw UnimplementedError();
 }

--- a/syncademic_app/lib/services/firestore_account_service.dart
+++ b/syncademic_app/lib/services/firestore_account_service.dart
@@ -20,8 +20,9 @@ class FirebaseAccountService extends AccountService {
 
   @override
   Future<void> createAccount(User user) async {
+    // TODO: Move this behavior to a cloud function for safety.
+
     if (await accountExists(user.id)) {
-      // TODO : or use Merge option to update the user document
       return;
     }
     try {

--- a/syncademic_app/pubspec.lock
+++ b/syncademic_app/pubspec.lock
@@ -13,26 +13,26 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: eb376e9acf6938204f90eb3b1f00b578640d3188b4c8a8ec054f9f479af8d051
+      sha256: "0b2f2bd91ba804e53a61d757b986f89f1f9eaed5b11e4b2f5a2468d86d6c9fc7"
       url: "https://pub.dev"
     source: hosted
-    version: "64.0.0"
+    version: "67.0.0"
   _flutterfire_internals:
     dependency: transitive
     description:
       name: _flutterfire_internals
-      sha256: "4eec93681221723a686ad580c2e7d960e1017cf1a4e0a263c2573c2c6b0bf5cd"
+      sha256: "99b5dec989287c1aca71bf27339e0022b4dc3679225f442fb75790ef44535bf8"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.25"
+    version: "1.3.30"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "69f54f967773f6c26c7dcb13e93d7ccee8b17a641689da39e878d5cf13b06893"
+      sha256: "37577842a27e4338429a1cbc32679d508836510b056f1eedf0c8d20e39c1383d"
       url: "https://pub.dev"
     source: hosted
-    version: "6.2.0"
+    version: "6.4.1"
   archive:
     dependency: transitive
     description:
@@ -45,10 +45,10 @@ packages:
     dependency: transitive
     description:
       name: args
-      sha256: eef6c46b622e0494a36c5a12d10d77fb4e855501a91c1b9ef9339326e58f0596
+      sha256: "7cf60b9f0cc88203c5a190b4cd62a99feea42759a7fa695010eb5de1c0b2252a"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.5.0"
   async:
     dependency: transitive
     description:
@@ -109,10 +109,10 @@ packages:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "581bacf68f89ec8792f5e5a0b2c4decd1c948e97ce659dc783688c8a88fbec21"
+      sha256: "3ac61a79bfb6f6cc11f693591063a7f19a7af628dc52f141743edac5c16e8c22"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.8"
+    version: "2.4.9"
   build_runner_core:
     dependency: transitive
     description:
@@ -133,10 +133,10 @@ packages:
     dependency: transitive
     description:
       name: built_value
-      sha256: fedde275e0a6b798c3296963c5cd224e3e1b55d0e478d5b7e65e6b540f363a0e
+      sha256: c7913a9737ee4007efedaffc968c049fd0f3d0e49109e778edc10de9426005cb
       url: "https://pub.dev"
     source: hosted
-    version: "8.9.1"
+    version: "8.9.2"
   characters:
     dependency: transitive
     description:
@@ -173,50 +173,50 @@ packages:
     dependency: "direct main"
     description:
       name: cloud_firestore
-      sha256: "31cfa4d65d6e9ea837234fffe121304034c30c9214c06207b4a35867e3757900"
+      sha256: "531a471f7eb9ae57bc8dc727c1fb424f7fe8817e84229fd527246af681bcf01c"
       url: "https://pub.dev"
     source: hosted
-    version: "4.15.8"
+    version: "4.17.0"
   cloud_firestore_platform_interface:
     dependency: transitive
     description:
       name: cloud_firestore_platform_interface
-      sha256: a0097a26569b015faf8142e159e855241609ea9a1738b5fd1c40bfe8411b41a0
+      sha256: "1014ed707aafc41828704eac18bc5ebad37641f66614db334e4f22e57ae7f568"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.9"
+    version: "6.2.0"
   cloud_firestore_web:
     dependency: transitive
     description:
       name: cloud_firestore_web
-      sha256: ed680ece29a5750985119c09cdc276b460c3a2fa80e8c12f9b7241f6b4a7ca16
+      sha256: be74d6d998807afe5bbe67c94ce4379b330c6817b8151488ce534a8c25d2df51
       url: "https://pub.dev"
     source: hosted
-    version: "3.10.8"
+    version: "3.12.0"
   cloud_functions:
     dependency: "direct main"
     description:
       name: cloud_functions
-      sha256: "25e2d24041233a86e62df6dfa82e506760ae42070486c5c09143b7fdf8c0f85a"
+      sha256: dbb3826232476d250d43a139360c7c4e3acfaeb48108bc8a76518b02bf56f15c
       url: "https://pub.dev"
     source: hosted
-    version: "4.6.8"
+    version: "4.7.2"
   cloud_functions_platform_interface:
     dependency: transitive
     description:
       name: cloud_functions_platform_interface
-      sha256: "4fad722fd2bf41ac1a318d12c5bdd1cc01ab69e372e8300d54e0cc6cd765a759"
+      sha256: c9e82c4a54306c7efa01014ee804b4965654cb780bab64dcc71461244722316c
       url: "https://pub.dev"
     source: hosted
-    version: "5.5.19"
+    version: "5.5.24"
   cloud_functions_web:
     dependency: transitive
     description:
       name: cloud_functions_web
-      sha256: "3bf4959d0795e2731aadc70d2ae4e9b5edc03a0e2e5939449c649ab8e04d4e1a"
+      sha256: c8f852e59aaa9eb428c1471080cfcce4feb293606c7ba58f643b2540392c989a
       url: "https://pub.dev"
     source: hosted
-    version: "4.7.2"
+    version: "4.9.2"
   code_builder:
     dependency: transitive
     description:
@@ -285,10 +285,10 @@ packages:
     dependency: transitive
     description:
       name: ffi
-      sha256: "7bf0adc28a23d395f19f3f1eb21dd7cfd1dd9f8e1c50051c069122e6853bc878"
+      sha256: "493f37e7df1804778ff3a53bd691d8692ddf69702cf4c1c1096a2e41b4779e21"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.2"
   file:
     dependency: transitive
     description:
@@ -301,34 +301,34 @@ packages:
     dependency: "direct main"
     description:
       name: firebase_auth
-      sha256: "17b841e1b000c3441b8ffceca88f468e078d0443db9643e77541bdfb7a3fd16b"
+      sha256: a35269247d7b23703bab35ecdb50462944ac1fcdfcf359a7071506c4ad830bfb
       url: "https://pub.dev"
     source: hosted
-    version: "4.17.8"
+    version: "4.19.2"
   firebase_auth_platform_interface:
     dependency: transitive
     description:
       name: firebase_auth_platform_interface
-      sha256: f294ceef40409a36c819a14280ca864fe487b44033e5276443377c66cb448310
+      sha256: "0edf2466247d18cd2111c4784e43bce49d39cc4d052c122e8060630a136b5a09"
       url: "https://pub.dev"
     source: hosted
-    version: "7.1.8"
+    version: "7.2.3"
   firebase_auth_web:
     dependency: transitive
     description:
       name: firebase_auth_web
-      sha256: "1f231da900fe7ff9f2974f8adcbdb3363c410c24725978afa5dc33e1e7e62e06"
+      sha256: "86da840704099da55b306ff3587a8aa72b1f541acfba266072263a896fd4b807"
       url: "https://pub.dev"
     source: hosted
-    version: "5.9.8"
+    version: "5.11.2"
   firebase_core:
     dependency: "direct main"
     description:
       name: firebase_core
-      sha256: "53316975310c8af75a96e365f9fccb67d1c544ef0acdbf0d88bbe30eedd1c4f9"
+      sha256: "6b1152a5af3b1cfe7e45309e96fc1aa14873f410f7aadb3878aa7812acfa7531"
       url: "https://pub.dev"
     source: hosted
-    version: "2.27.0"
+    version: "2.30.0"
   firebase_core_platform_interface:
     dependency: transitive
     description:
@@ -341,10 +341,10 @@ packages:
     dependency: transitive
     description:
       name: firebase_core_web
-      sha256: c8e1d59385eee98de63c92f961d2a7062c5d9a65e7f45bdc7f1b0b205aab2492
+      sha256: c8b02226e548f35aace298e2bb2e6c24e34e8a203d614e742bb1146e5a4ad3c8
       url: "https://pub.dev"
     source: hosted
-    version: "2.11.5"
+    version: "2.15.0"
   fixnum:
     dependency: transitive
     description:
@@ -428,10 +428,10 @@ packages:
     dependency: "direct dev"
     description:
       name: freezed
-      sha256: "57247f692f35f068cae297549a46a9a097100685c6780fe67177503eea5ed4e5"
+      sha256: a434911f643466d78462625df76fd9eb13e57348ff43fe1f77bbe909522c67a1
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.7"
+    version: "2.5.2"
   freezed_annotation:
     dependency: "direct main"
     description:
@@ -444,10 +444,10 @@ packages:
     dependency: transitive
     description:
       name: frontend_server_client
-      sha256: "408e3ca148b31c20282ad6f37ebfa6f4bdc8fede5b74bc2f08d9d92b55db3612"
+      sha256: f64a0333a82f30b0cca061bc3d143813a486dc086b574bfb233b7c1372427694
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.0"
+    version: "4.0.0"
   gap:
     dependency: "direct main"
     description:
@@ -460,10 +460,10 @@ packages:
     dependency: "direct main"
     description:
       name: get_it
-      sha256: e6017ce7fdeaf218dc51a100344d8cb70134b80e28b760f8bb23c242437bafd7
+      sha256: d85128a5dae4ea777324730dc65edd9c9f43155c109d5cc0a69cab74139fbac1
       url: "https://pub.dev"
     source: hosted
-    version: "7.6.7"
+    version: "7.7.0"
   get_time_ago:
     dependency: "direct main"
     description:
@@ -484,10 +484,10 @@ packages:
     dependency: "direct main"
     description:
       name: go_router
-      sha256: "7ecb2f391edbca5473db591b48555a8912dde60edd0fb3013bd6743033b2d3f8"
+      sha256: "771c8feb40ad0ef639973d7ecf1b43d55ffcedb2207fd43fab030f5639e40446"
       url: "https://pub.dev"
     source: hosted
-    version: "13.2.1"
+    version: "13.2.4"
   google_fonts:
     dependency: "direct main"
     description:
@@ -500,10 +500,10 @@ packages:
     dependency: transitive
     description:
       name: google_identity_services_web
-      sha256: "0c56c2c5d60d6dfaf9725f5ad4699f04749fb196ee5a70487a46ef184837ccf6"
+      sha256: "9482364c9f8b7bd36902572ebc3a7c2b5c8ee57a9c93e6eb5099c1a9ec5265d8"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0+2"
+    version: "0.3.1+1"
   google_sign_in:
     dependency: "direct main"
     description:
@@ -516,18 +516,18 @@ packages:
     dependency: transitive
     description:
       name: google_sign_in_android
-      sha256: "38cef11ed22fc0c9bfa7b00bf7f2d91012138f5613089522917fd26c853be93e"
+      sha256: "7647893c65e6720973f0e579051c8f84b877b486614d9f70a404259c41a4632e"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.22"
+    version: "6.1.23"
   google_sign_in_ios:
     dependency: transitive
     description:
       name: google_sign_in_ios
-      sha256: a7d653803468d30b82ceb47ea00fe86d23c56e63eb2e5c2248bb68e9df203217
+      sha256: "1e0d4fde6cc07a8ff423f6bc931e83a74163d6af702004bacaee752649fdd2e7"
       url: "https://pub.dev"
     source: hosted
-    version: "5.7.4"
+    version: "5.7.5"
   google_sign_in_platform_interface:
     dependency: transitive
     description:
@@ -540,10 +540,10 @@ packages:
     dependency: "direct main"
     description:
       name: google_sign_in_web
-      sha256: a278ea2d01013faf341cbb093da880d0f2a552bbd1cb6ee90b5bebac9ba69d77
+      sha256: fc0f14ed45ea616a6cfb4d1c7534c2221b7092cc4f29a709f0c3053cc3e821bd
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.3+2"
+    version: "0.12.4"
   googleapis:
     dependency: "direct main"
     description:
@@ -556,10 +556,10 @@ packages:
     dependency: transitive
     description:
       name: googleapis_auth
-      sha256: "1401a9e55f9e0f565d3eebb18d990290f53a12d38a5f7f0230b112895778a85b"
+      sha256: befd71383a955535060acde8792e7efc11d2fccd03dd1d3ec434e85b68775938
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.1"
+    version: "1.6.0"
   graphs:
     dependency: transitive
     description:
@@ -572,10 +572,10 @@ packages:
     dependency: "direct main"
     description:
       name: http
-      sha256: a2bbf9d017fcced29139daa8ed2bba4ece450ab222871df93ca9eec6f80c34ba
+      sha256: "761a297c042deedc1ffbb156d6e2af13886bb305c2a343a4d972504cd67dd938"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   http_multi_server:
     dependency: transitive
     description:
@@ -620,10 +620,10 @@ packages:
     dependency: transitive
     description:
       name: js
-      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
+      sha256: c1b2e9b5ea78c45e1a0788d29606ba27dc5f71f019f32ca5140f61ef071838cf
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.7"
+    version: "0.7.1"
   json_annotation:
     dependency: transitive
     description:
@@ -740,18 +740,18 @@ packages:
     dependency: transitive
     description:
       name: path_provider
-      sha256: b27217933eeeba8ff24845c34003b003b2b22151de3c908d0e679e8fe1aa078b
+      sha256: c9e7d3a4cd1410877472158bee69963a4579f78b68c65a2b7d40d1a7a88bb161
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.3"
   path_provider_android:
     dependency: transitive
     description:
       name: path_provider_android
-      sha256: "477184d672607c0a3bf68fbbf601805f92ef79c82b64b4d6eb318cbca4c48668"
+      sha256: a248d8146ee5983446bf03ed5ea8f6533129a12b11f12057ad1b4a67a2b3b41d
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.2"
+    version: "2.2.4"
   path_provider_foundation:
     dependency: transitive
     description:
@@ -812,10 +812,10 @@ packages:
     dependency: transitive
     description:
       name: pointycastle
-      sha256: "43ac87de6e10afabc85c445745a7b799e04de84cebaa4fd7bf55a5e1e9604d29"
+      sha256: "70fe966348fe08c34bf929582f1d8247d9d9408130723206472b4687227e4333"
       url: "https://pub.dev"
     source: hosted
-    version: "3.7.4"
+    version: "3.8.0"
   pool:
     dependency: transitive
     description:
@@ -969,10 +969,10 @@ packages:
     dependency: "direct main"
     description:
       name: uuid
-      sha256: cd210a09f7c18cbe5a02511718e0334de6559871052c90a90c0cca46a4aa81c8
+      sha256: "814e9e88f21a176ae1359149021870e87f7cddaf633ab678a5d2b0bff7fd1ba8"
       url: "https://pub.dev"
     source: hosted
-    version: "4.3.3"
+    version: "4.4.0"
   validators:
     dependency: "direct main"
     description:
@@ -1033,26 +1033,26 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
+      sha256: "97da13628db363c635202ad97068d47c5b8aa555808e7a9411963c533b449b27"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0"
+    version: "0.5.1"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      sha256: d88238e5eac9a42bb43ca4e721edba3c08c6354d4a53063afaa568516217621b
+      sha256: "58c6666b342a38816b2e7e50ed0f1e261959630becd4c879c4f26bfa14aa5a42"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.0"
+    version: "2.4.5"
   win32:
     dependency: transitive
     description:
       name: win32
-      sha256: "464f5674532865248444b4c3daca12bd9bf2d7c47f759ce2617986e7229494a8"
+      sha256: "0a989dc7ca2bb51eac91e8fd00851297cfffd641aa7538b165c62637ca0eaa4a"
       url: "https://pub.dev"
     source: hosted
-    version: "5.2.0"
+    version: "5.4.0"
   xdg_directories:
     dependency: transitive
     description:
@@ -1078,5 +1078,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.2.6 <4.0.0"
-  flutter: ">=3.16.6"
+  dart: ">=3.3.0 <4.0.0"
+  flutter: ">=3.19.0"

--- a/syncademic_app/test/models/sync_profile_test.dart
+++ b/syncademic_app/test/models/sync_profile_test.dart
@@ -15,6 +15,7 @@ void main() {
   final targetCalendar = TargetCalendar(
     id: ID(),
     title: 'targetCalendarTitle',
+    accountOwnerUserId: 'accountOwnerUserId',
   );
 
   test('should create a SyncProfile instance', () {

--- a/syncademic_app/test/models/target_calendar_test.dart
+++ b/syncademic_app/test/models/target_calendar_test.dart
@@ -5,68 +5,71 @@ import 'package:syncademic_app/models/target_calendar.dart';
 void main() {
   const id = ID.fromString('test_id');
   const title = 'Test Title';
+  const accountOwnerUserId = 'accountOwnerUserId';
+
+  TargetCalendar createTargetCalendar({
+    ID id = id,
+    String title = title,
+    String accountOwnerUserId = accountOwnerUserId,
+  }) =>
+      TargetCalendar(
+        id: id,
+        title: title,
+        accountOwnerUserId: accountOwnerUserId,
+      );
 
   test('should create a TargetCalendar instance', () {
     const targetCalendar = TargetCalendar(
       id: id,
       title: title,
+      accountOwnerUserId: accountOwnerUserId,
     );
 
     expect(targetCalendar.id, id);
     expect(targetCalendar.title, title);
+    expect(targetCalendar.accountOwnerUserId, accountOwnerUserId);
   });
 
   group('equals', () {
     test('should be equal to another TargetCalendar with the values', () {
-      const targetCalendar1 = TargetCalendar(
-        id: id,
-        title: title,
-      );
-      const targetCalendar2 = TargetCalendar(
-        id: id,
-        title: title,
-      );
+      final targetCalendar1 = createTargetCalendar();
+      final targetCalendar2 = createTargetCalendar();
       expect(targetCalendar1, equals(targetCalendar2));
     });
 
     test('should not be equal to another TargetCalendar with a different id',
         () {
-      const id1 = ID.fromString('test_id1');
-      const targetCalendar1 = TargetCalendar(
-        id: id1,
-        title: title,
-      );
-      const targetCalendar2 = TargetCalendar(
-        id: id,
-        title: title,
-      );
+      final targetCalendar1 =
+          createTargetCalendar(id: const ID.fromString("A"));
+      final targetCalendar2 =
+          createTargetCalendar(id: const ID.fromString("B"));
+
       expect(targetCalendar1, isNot(equals(targetCalendar2)));
     });
 
     test('should not be equal to another TargetCalendar with a different title',
         () {
-      const title1 = 'Test Title 1';
-      const targetCalendar1 = TargetCalendar(
-        id: id,
-        title: title1,
-      );
-      const targetCalendar2 = TargetCalendar(
-        id: id,
-        title: title,
-      );
+      final targetCalendar1 = createTargetCalendar(title: 'A');
+      final targetCalendar2 = createTargetCalendar(title: 'B');
+
       expect(targetCalendar1, isNot(equals(targetCalendar2)));
     });
 
-    test('should have the same hash code for TargetCalendars with the values',
+    test(
+        'should not be equal to another TargetCalendar with a different accountOwnerUserId',
         () {
-      const targetCalendar1 = TargetCalendar(
-        id: id,
-        title: title,
-      );
-      const targetCalendar2 = TargetCalendar(
-        id: id,
-        title: title,
-      );
+      final targetCalendar1 = createTargetCalendar(accountOwnerUserId: 'A');
+      final targetCalendar2 = createTargetCalendar(accountOwnerUserId: 'B');
+
+      expect(targetCalendar1, isNot(equals(targetCalendar2)));
+    });
+
+    test(
+        'should have the same hash code for TargetCalendars with the same values',
+        () {
+      final targetCalendar1 = createTargetCalendar();
+      final targetCalendar2 = createTargetCalendar();
+
       expect(targetCalendar1.hashCode, equals(targetCalendar2.hashCode));
     });
   });

--- a/syncademic_app/test/models/target_calendar_test.dart
+++ b/syncademic_app/test/models/target_calendar_test.dart
@@ -5,18 +5,15 @@ import 'package:syncademic_app/models/target_calendar.dart';
 void main() {
   const id = ID.fromString('test_id');
   const title = 'Test Title';
-  const accessToken = 'test_access_token';
 
   test('should create a TargetCalendar instance', () {
     const targetCalendar = TargetCalendar(
       id: id,
       title: title,
-      accessToken: accessToken,
     );
 
     expect(targetCalendar.id, id);
     expect(targetCalendar.title, title);
-    expect(targetCalendar.accessToken, accessToken);
   });
 
   group('equals', () {
@@ -24,12 +21,10 @@ void main() {
       const targetCalendar1 = TargetCalendar(
         id: id,
         title: title,
-        accessToken: accessToken,
       );
       const targetCalendar2 = TargetCalendar(
         id: id,
         title: title,
-        accessToken: accessToken,
       );
       expect(targetCalendar1, equals(targetCalendar2));
     });
@@ -40,12 +35,10 @@ void main() {
       const targetCalendar1 = TargetCalendar(
         id: id1,
         title: title,
-        accessToken: accessToken,
       );
       const targetCalendar2 = TargetCalendar(
         id: id,
         title: title,
-        accessToken: accessToken,
       );
       expect(targetCalendar1, isNot(equals(targetCalendar2)));
     });
@@ -56,29 +49,10 @@ void main() {
       const targetCalendar1 = TargetCalendar(
         id: id,
         title: title1,
-        accessToken: accessToken,
       );
       const targetCalendar2 = TargetCalendar(
         id: id,
         title: title,
-        accessToken: accessToken,
-      );
-      expect(targetCalendar1, isNot(equals(targetCalendar2)));
-    });
-
-    test(
-        'should not be equal to another TargetCalendar with a different accessToken',
-        () {
-      const accessToken1 = 'test_access_token1';
-      const targetCalendar1 = TargetCalendar(
-        id: id,
-        title: title,
-        accessToken: accessToken1,
-      );
-      const targetCalendar2 = TargetCalendar(
-        id: id,
-        title: title,
-        accessToken: accessToken,
       );
       expect(targetCalendar1, isNot(equals(targetCalendar2)));
     });
@@ -88,12 +62,10 @@ void main() {
       const targetCalendar1 = TargetCalendar(
         id: id,
         title: title,
-        accessToken: accessToken,
       );
       const targetCalendar2 = TargetCalendar(
         id: id,
         title: title,
-        accessToken: accessToken,
       );
       expect(targetCalendar1.hashCode, equals(targetCalendar2.hashCode));
     });


### PR DESCRIPTION
- Move the access and refresh tokens to a separate firestore collection (`backendAuthorizations`)
- Allows a single user to have multiple syncProfiles with targetCalendars on multiple Google Accounts
- We automatically get refresh tokens, allowing for future background synchronizations