### PR TITLE
Add all events on first sync

### DIFF
--- a/functions/main.py
+++ b/functions/main.py
@@ -191,7 +191,7 @@ def _synchronize_now(
     )
 
     # TODO create CalendarManager here. This will allow us to test the authorization
-    # and avoid doing it in the synchronization function
+    # and avoid doing it in the synchronization function. and report the error to the user
 
     try:
         service = get_calendar_service(
@@ -217,6 +217,7 @@ def _synchronize_now(
             icsSourceUrl=doc.get("scheduleSource.url"),
             targetCalendarId=doc.get("targetCalendar.id"),
             service=service,
+            syncTrigger=sync_trigger,
             middlewares=[TitlePrettifier, ExamPrettifier],
         )
     except Exception as e:


### PR DESCRIPTION
When the syncProfile has just been created, and the first synchronization is triggered, we want all the events of the time schedule to be synchonized, even those in the past