### PR TITLE
Use env variables to define redirect uris

### DIFF
--- a/functions/main.py
+++ b/functions/main.py
@@ -50,6 +50,9 @@ initialize_app()
 CLIENT_ID = StringParam("CLIENT_ID")
 CLIENT_SECRET = StringParam("CLIENT_SECRET")
 
+LOCAL_REDIRECT_URI = StringParam("LOCAL_REDIRECT_URI")
+PRODUCTION_REDIRECT_URI = StringParam("PRODUCTION_REDIRECT_URI")
+
 
 def get_calendar_service(user_id: str, provider_account_id: str):
     if not user_id:
@@ -471,8 +474,8 @@ def authorize_backend(request: https_fn.CallableRequest) -> dict:
             https_fn.FunctionsErrorCode.INVALID_ARGUMENT, "Missing authorization code"
         )
 
-    redirect_uri = request.data.get("redirectUri", "https://syncademic.io")
-    if redirect_uri not in ["https://syncademic.io", "http://localhost:7357"]:
+    redirect_uri = request.data.get("redirectUri", PRODUCTION_REDIRECT_URI)
+    if redirect_uri not in [PRODUCTION_REDIRECT_URI, LOCAL_REDIRECT_URI]:
         raise https_fn.HttpsError(
             https_fn.FunctionsErrorCode.INVALID_ARGUMENT, "Invalid redirect URI"
         )

--- a/syncademic_app/dotenv
+++ b/syncademic_app/dotenv
@@ -1,2 +1,5 @@
-SYNCADEMIC_CLIENT_ID = '776699153814-fqlr8rl50mst6pco4eaf8cr881jkjdps.apps.googleusercontent.com'
-
+SYNCADEMIC_CLIENT_ID = (
+    "776699153814-fqlr8rl50mst6pco4eaf8cr881jkjdps.apps.googleusercontent.com"
+)
+LOCAL_REDIRECT_URI = "http://localhost:7357"
+PRODUCTION_REDIRECT_URI = "https://app.syncademic.io"

--- a/syncademic_app/dotenv
+++ b/syncademic_app/dotenv
@@ -1,5 +1,5 @@
-SYNCADEMIC_CLIENT_ID = (
-    "776699153814-fqlr8rl50mst6pco4eaf8cr881jkjdps.apps.googleusercontent.com"
-)
+#! THIS FILE IS SOURCE CONTROLLED. DO NOT ADD SENSITIVE INFORMATION TO THIS FILE. (e.g NO CLIENT_SECRET)
+
+SYNCADEMIC_CLIENT_ID = "776699153814-fqlr8rl50mst6pco4eaf8cr881jkjdps.apps.googleusercontent.com"
 LOCAL_REDIRECT_URI = "http://localhost:7357"
 PRODUCTION_REDIRECT_URI = "https://app.syncademic.io"

--- a/syncademic_app/dotenv.template
+++ b/syncademic_app/dotenv.template
@@ -1,3 +1,0 @@
-SYNCADEMIC_OAUTH_CLIENT_ID='YOUR_CLIENT_ID'
-LOCAL_REDIRECT_URI = "http://localhost:7357"
-PRODUCTION_REDIRECT_URI = "https://app.syncademic.io"

--- a/syncademic_app/dotenv.template
+++ b/syncademic_app/dotenv.template
@@ -1,1 +1,3 @@
 SYNCADEMIC_OAUTH_CLIENT_ID='YOUR_CLIENT_ID'
+LOCAL_REDIRECT_URI = "http://localhost:7357"
+PRODUCTION_REDIRECT_URI = "https://app.syncademic.io"

--- a/syncademic_app/lib/authorization/firebase_backend_authorization_service.dart
+++ b/syncademic_app/lib/authorization/firebase_backend_authorization_service.dart
@@ -10,8 +10,7 @@ class FirebaseBackendAuthorizationService
     implements BackendAuthorizationService {
   final String redirectUri;
 
-  FirebaseBackendAuthorizationService(
-      {this.redirectUri = 'https://syncademic.io'});
+  FirebaseBackendAuthorizationService({required this.redirectUri});
 
   @override
   Future<void> authorizeBackend(ProviderAccount providerAccount) async {

--- a/syncademic_app/lib/main.dart
+++ b/syncademic_app/lib/main.dart
@@ -81,9 +81,12 @@ void main() async {
     // MockBackendAuthorizationService(),
     //
     // Local :
-    // FirebaseBackendAuthorizationService(redirectUri: 'http://localhost:7357'),
+    // FirebaseBackendAuthorizationService(
+    //     redirectUri: dotenv.env['LOCAL_REDIRECT_URI']!),
     //
     // Production :
+    FirebaseBackendAuthorizationService(
+        redirectUri: dotenv.env['PRODUCTION_REDIRECT_URI']!),
     FirebaseBackendAuthorizationService(),
   );
 

--- a/syncademic_app/lib/main.dart
+++ b/syncademic_app/lib/main.dart
@@ -87,7 +87,6 @@ void main() async {
     // Production :
     FirebaseBackendAuthorizationService(
         redirectUri: dotenv.env['PRODUCTION_REDIRECT_URI']!),
-    FirebaseBackendAuthorizationService(),
   );
 
   getIt.registerSingleton<TargetCalendarRepository>(

--- a/syncademic_app/pubspec.yaml
+++ b/syncademic_app/pubspec.yaml
@@ -17,7 +17,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.1.8
+version: 0.1.9
 
 environment:
   sdk: '>=3.2.6 <4.0.0'


### PR DESCRIPTION
To change the OAuth redirect uris from `syncademic.io` to `app.syncademic.io`, I use env vars instead of hardcoding