### PR TITLE
Use google gis sdk

### DIFF
--- a/syncademic_app/lib/main.dart
+++ b/syncademic_app/lib/main.dart
@@ -6,20 +6,19 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:get_it/get_it.dart';
 import 'package:go_router/go_router.dart';
 import 'package:google_sign_in/google_sign_in.dart';
-import 'package:googleapis/calendar/v3.dart' as gcal_api;
-import 'services/provider_account_service.dart';
-import 'repositories/google_target_calendar_repository.dart';
-import 'repositories/target_calendar_repository.dart';
-import 'authorization/firebase_backend_authorization_service.dart';
-import 'authorization/google_authorization/google_authorization_service.dart';
-import 'services/firebase_sync_profile_service.dart';
+import 'package:googleapis/calendar/v3.dart' show CalendarApi;
+import 'package:package_info_plus/package_info_plus.dart';
 
 import 'authentication/cubit/auth_cubit.dart';
 import 'authorization/authorization_service.dart';
 import 'authorization/backend_authorization_service.dart';
+import 'authorization/firebase_backend_authorization_service.dart';
+import 'authorization/google_authorization/google_authorization_service.dart';
 import 'firebase_options.dart';
 import 'repositories/firestore_sync_profile_repository.dart';
+import 'repositories/google_target_calendar_repository.dart';
 import 'repositories/sync_profile_repository.dart';
+import 'repositories/target_calendar_repository.dart';
 import 'screens/account/account_page.dart';
 import 'screens/landing_page.dart';
 import 'screens/new_sync_profile/cubit/new_sync_profile_cubit.dart';
@@ -29,10 +28,11 @@ import 'screens/sync_profile/sync_profile_page.dart';
 import 'services/account_service.dart';
 import 'services/auth_service.dart';
 import 'services/firebase_auth_service.dart';
+import 'services/firebase_sync_profile_service.dart';
 import 'services/firestore_account_service.dart';
+import 'services/provider_account_service.dart';
 import 'services/sync_profile_service.dart';
 import 'widgets/sync_profiles_list.dart';
-import 'package:package_info_plus/package_info_plus.dart';
 
 void main() async {
   await dotenv.load(fileName: "dotenv");
@@ -48,7 +48,7 @@ void main() async {
   final googleSignIn = GoogleSignIn(
     clientId: dotenv.env['SYNCADEMIC_CLIENT_ID'],
     forceCodeForRefreshToken: true,
-    scopes: [gcal_api.CalendarApi.calendarScope],
+    scopes: [CalendarApi.calendarScope],
   );
 
   getIt.registerSingleton<SyncProfileRepository>(
@@ -146,11 +146,23 @@ final _router = GoRouter(
         builder: (_, __) {
           return BlocProvider(
             create: (_) => NewSyncProfileCubit(),
+            // create: (_) => NewSyncProfileCubit()
+            //   ..titleChanged("test")
+            //   ..next()
+            //   ..urlChanged("https://www.google.com")
+            //   ..next(),
             child: const NewSyncProfilePage(),
           );
         }),
   ],
 );
+
+class HomeScreen extends StatefulWidget {
+  const HomeScreen({super.key});
+
+  @override
+  State<HomeScreen> createState() => _HomeScreenState();
+}
 
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
@@ -169,23 +181,8 @@ class MyApp extends StatelessWidget {
   }
 }
 
-class HomeScreen extends StatefulWidget {
-  const HomeScreen({super.key});
-
-  @override
-  State<HomeScreen> createState() => _HomeScreenState();
-}
-
 class _HomeScreenState extends State<HomeScreen> {
   PackageInfo? packageInfo;
-
-  @override
-  void initState() {
-    super.initState();
-    PackageInfo.fromPlatform().then((value) => setState(() {
-          packageInfo = value;
-        }));
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -234,5 +231,13 @@ class _HomeScreenState extends State<HomeScreen> {
         label: const Text('New synchronization profile'),
       ),
     );
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    PackageInfo.fromPlatform().then((value) => setState(() {
+          packageInfo = value;
+        }));
   }
 }

--- a/syncademic_app/lib/screens/new_sync_profile/google_sign_in_button/sign_in_button.dart
+++ b/syncademic_app/lib/screens/new_sync_profile/google_sign_in_button/sign_in_button.dart
@@ -1,0 +1,7 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+export 'sign_in_button/stub.dart'
+    if (dart.library.js_util) 'sign_in_button/web.dart'
+    if (dart.library.io) 'sign_in_button/mobile.dart';

--- a/syncademic_app/lib/screens/new_sync_profile/google_sign_in_button/sign_in_button/mobile.dart
+++ b/syncademic_app/lib/screens/new_sync_profile/google_sign_in_button/sign_in_button/mobile.dart
@@ -1,0 +1,15 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+
+import 'stub.dart';
+
+/// Renders a SIGN IN button that calls `handleSignIn` onclick.
+Widget buildSignInButton({HandleSignInFn? onPressed}) {
+  return TextButton(
+    onPressed: onPressed,
+    child: const Text('Select your Google Account'),
+  );
+}

--- a/syncademic_app/lib/screens/new_sync_profile/google_sign_in_button/sign_in_button/stub.dart
+++ b/syncademic_app/lib/screens/new_sync_profile/google_sign_in_button/sign_in_button/stub.dart
@@ -1,0 +1,18 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+/// The type of the onClick callback for the (mobile) Sign In Button.
+typedef HandleSignInFn = Future<void> Function();
+
+/// Renders a Sign In button that, on mobile, calls the `handleSignIn`,
+/// and on web, renders a web-only button that authenticates the user but
+/// does not call `handleSignIn`. Instead, on web, you should listen to
+/// `onCurrentUserChanged` on the googleSignIn instance.
+Widget buildSignInButton({HandleSignInFn? onPressed}) {
+  return Container();
+}

--- a/syncademic_app/lib/screens/new_sync_profile/google_sign_in_button/sign_in_button/web.dart
+++ b/syncademic_app/lib/screens/new_sync_profile/google_sign_in_button/sign_in_button/web.dart
@@ -1,0 +1,13 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:google_sign_in_web/web_only.dart' as web;
+
+import 'stub.dart';
+
+/// Renders a web-only SIGN IN button.
+Widget buildSignInButton({HandleSignInFn? onPressed}) {
+  return web.renderButton();
+}

--- a/syncademic_app/lib/screens/new_sync_profile/new_sync_profile_page.dart
+++ b/syncademic_app/lib/screens/new_sync_profile/new_sync_profile_page.dart
@@ -1,7 +1,6 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/gestures.dart';
-import 'package:google_sign_in_web/web_only.dart' as google_sign_in_web;
+import 'package:syncademic_app/screens/new_sync_profile/google_sign_in_button/sign_in_button.dart';
 
 import 'package:url_launcher/url_launcher.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -169,14 +168,10 @@ class ProviderAccountStepContent extends StatelessWidget {
         if (state.providerAccount == null) {
           return Column(
             children: [
-              kIsWeb
-                  ? google_sign_in_web.renderButton()
-                  : TextButton(
-                      onPressed: context
-                          .read<NewSyncProfileCubit>()
-                          .pickProviderAccount,
-                      child: const Text('Select your Google Account'),
-                    ),
+              buildSignInButton(
+                onPressed:
+                    context.read<NewSyncProfileCubit>().pickProviderAccount,
+              ),
             ],
           );
         } else {

--- a/syncademic_app/lib/screens/new_sync_profile/new_sync_profile_page.dart
+++ b/syncademic_app/lib/screens/new_sync_profile/new_sync_profile_page.dart
@@ -1,5 +1,8 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/gestures.dart';
+import 'package:google_sign_in_web/web_only.dart' as google_sign_in_web;
+
 import 'package:url_launcher/url_launcher.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:gap/gap.dart';
@@ -166,11 +169,14 @@ class ProviderAccountStepContent extends StatelessWidget {
         if (state.providerAccount == null) {
           return Column(
             children: [
-              TextButton(
-                onPressed:
-                    context.read<NewSyncProfileCubit>().pickProviderAccount,
-                child: const Text('Select your Google Account'),
-              ),
+              kIsWeb
+                  ? google_sign_in_web.renderButton()
+                  : TextButton(
+                      onPressed: context
+                          .read<NewSyncProfileCubit>()
+                          .pickProviderAccount,
+                      child: const Text('Select your Google Account'),
+                    ),
             ],
           );
         } else {

--- a/syncademic_app/lib/services/provider_account_service.dart
+++ b/syncademic_app/lib/services/provider_account_service.dart
@@ -13,6 +13,8 @@ abstract class ProviderAccountService {
   /// to [triggerProviderAccountSelection] will open the dialog instead
   /// of returning a cached value.
   Future<void> reset();
+
+  Stream<ProviderAccount?> get onCurrentUserChanged;
 }
 
 class MockProviderAccountService implements ProviderAccountService {
@@ -30,12 +32,34 @@ class MockProviderAccountService implements ProviderAccountService {
   Future<void> reset() async {
     await Future.delayed(const Duration(microseconds: 1));
   }
+
+  @override
+  Stream<ProviderAccount?> get onCurrentUserChanged =>
+      Stream.value(const ProviderAccount(
+        provider: Provider.google,
+        providerAccountId: 'mock-provider-account-id',
+        providerAccountEmail: 'info@syncademic.io',
+      ));
 }
 
 class GoogleProviderAccountService implements ProviderAccountService {
   final GoogleSignIn googleSignIn;
 
   GoogleProviderAccountService({required this.googleSignIn});
+
+  @override
+  Stream<ProviderAccount?> get onCurrentUserChanged =>
+      googleSignIn.onCurrentUserChanged.map((GoogleSignInAccount? account) {
+        if (account == null) {
+          return null;
+        }
+
+        return ProviderAccount(
+          provider: Provider.google,
+          providerAccountId: account.id,
+          providerAccountEmail: account.email,
+        );
+      });
 
   @override
   Future<ProviderAccount?> triggerProviderAccountSelection() async {

--- a/syncademic_app/pubspec.yaml
+++ b/syncademic_app/pubspec.yaml
@@ -3,7 +3,7 @@ description: "Syncademic.io Frontend"
 
 # The following line prevents the package from being accidentally published to
 # pub.dev using `flutter pub publish`. This is preferred for private packages.
-publish_to: 'none' # Remove this line if you wish to publish to pub.dev
+publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
 # The following defines the version and build number for your application.
 # A version number is three numbers separated by dots, like 1.2.43
@@ -17,10 +17,10 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.1.10
+version: 0.1.11
 
 environment:
-  sdk: '>=3.2.6 <4.0.0'
+  sdk: ">=3.2.6 <4.0.0"
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions
@@ -31,7 +31,6 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-
 
   gap: ^3.0.1
   equatable: ^2.0.5
@@ -77,7 +76,6 @@ dev_dependencies:
 
 # The following section is specific to Flutter packages.
 flutter:
-
   # The following line ensures that the Material Icons font is
   # included with your application, so that you can use the icons in
   # the material Icons class.


### PR DESCRIPTION
Previously, on web, we were using the `signIn` method of `GoogleSignIn`. However, this method would perform the authorization immediately with the specified scopes, when we would only require authentication. We thus use the new recommended approach, which is the `renderButton` method of `google_sign_in_web`.