### PR TITLE
Store ICS files for future use

### DIFF
--- a/functions/main.py
+++ b/functions/main.py
@@ -18,7 +18,7 @@ from firebase_functions.firestore_fn import (
 )
 from firebase_functions import options
 
-from firebase_admin import initialize_app, firestore
+from firebase_admin import initialize_app, firestore, storage
 from firebase_functions.params import StringParam
 
 from firebase_functions import https_fn, logger, scheduler_fn
@@ -324,11 +324,12 @@ def _synchronize_now(
 
     try:
         perform_synchronization(
-            syncProfileId=sync_profile_id,
-            icsSourceUrl=doc.get("scheduleSource.url"),
-            targetCalendarId=doc.get("targetCalendar.id"),
+            sync_profile_id=sync_profile_id,
+            ics_source_url=doc.get("scheduleSource.url"),
+            target_calendar_id=doc.get("targetCalendar.id"),
             service=service,
-            syncTrigger=sync_trigger,
+            sync_trigger=sync_trigger,
+            firebase_storage_bucket=storage.bucket(),
             middlewares=[TitlePrettifier, ExamPrettifier],
         )
     except Exception as e:

--- a/functions/synchronizer/synchronizer/synchronizer.py
+++ b/functions/synchronizer/synchronizer/synchronizer.py
@@ -1,4 +1,3 @@
-from dataclasses import dataclass
 from datetime import datetime, timezone
 import logging
 from typing import List, Optional
@@ -6,23 +5,23 @@ from .middleware.middleware import Middleware
 from .google_calendar_manager import GoogleCalendarManager
 from .ics_parser import IcsParser
 from .ics_source import UrlIcsSource
-
+from google.cloud import storage
 
 logger = logging.getLogger(__name__)  # TODO: get logger from cloud functions
 
 
 def perform_synchronization(
-    # TODO : change parameters to snake_case
-    syncProfileId: str,  # This value is inserted as a property in events to avoid deleting user events
-    icsSourceUrl: str,
-    targetCalendarId: str,
+    sync_profile_id: str,  # This value is inserted as a property in events to avoid deleting user events
+    ics_source_url: str,
+    target_calendar_id: str,
     service,
-    syncTrigger: str,
+    sync_trigger: str,
+    firebase_storage_bucket: storage.Bucket,
     middlewares: Optional[List[Middleware]] = None,
 ) -> None:
     try:
         ics_str = UrlIcsSource(
-            icsSourceUrl
+            ics_source_url
         ).get_ics_string()  # TODO : Add proper error when url is invalid
     except Exception as e:
         logger.error(f"Failed to get ics string: {e}")
@@ -33,6 +32,23 @@ def perform_synchronization(
     except Exception as e:
         logger.error(f"Failed to parse ics: {e}")
         raise e
+
+    # Store ics string in firebase storage
+    try:
+        filename = f"{sync_profile_id}_{datetime.now(timezone.utc).strftime('%Y-%m-%d_%H-%M-%S')}.ics"
+        blob = firebase_storage_bucket.blob(filename)
+
+        blob.metadata = {
+            "sourceUrl": ics_source_url,
+            "syncProfileId": sync_profile_id,
+            "syncTrigger": sync_trigger,
+            "blob_created_at": datetime.now(timezone.utc).isoformat(),
+        }
+        blob.upload_from_string(ics_str, content_type="text/calendar")
+
+    except Exception as e:
+        logger.error(f"Failed to store ics string in firebase storage. {e}")
+        # Do not raise, we want to continue the execution
 
     try:
         if middlewares:
@@ -46,22 +62,22 @@ def perform_synchronization(
         logger.warning("No events to synchronize")
         return
 
-    calendar_manager = GoogleCalendarManager(service, targetCalendarId)
+    calendar_manager = GoogleCalendarManager(service, target_calendar_id)
 
     calendar_manager.test_authorization()
 
     separation_dt = datetime.now(timezone.utc)
 
-    if syncTrigger == "on_create":
-        return calendar_manager.create_events(events, syncProfileId)
+    if sync_trigger == "on_create":
+        return calendar_manager.create_events(events, sync_profile_id)
 
     # TODO : Only update events that have changed
     future_events_ids = calendar_manager.get_events_ids_from_sync_profile(
-        syncProfileId, separation_dt
+        sync_profile_id, separation_dt
     )
 
     calendar_manager.delete_events(future_events_ids)
 
     new_events = [event for event in events if event.end > separation_dt]
 
-    calendar_manager.create_events(new_events, syncProfileId)
+    calendar_manager.create_events(new_events, sync_profile_id)


### PR DESCRIPTION
Syncademic currently fetches and processes ICS files for each synchronization, even when there are no changes. This leads to inefficient use of resources and unnecessary updates to users' Google Calendars. The system needs to:

1. **Store ICS files from each synchronization** <-- THIS PR
2. Compare new ICS files with previously stored versions
3. Update only changed events in users' calendars

Implementing this caching mechanism will improve system efficiency, reduce unnecessary calendar updates, and provide data for future tests.