### PR TITLE
test GoogleCalendarManager

### DIFF
--- a/functions/poetry.lock
+++ b/functions/poetry.lock
@@ -1514,6 +1514,33 @@ files = [
 pyasn1 = ">=0.1.3"
 
 [[package]]
+name = "ruff"
+version = "0.6.9"
+description = "An extremely fast Python linter and code formatter, written in Rust."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "ruff-0.6.9-py3-none-linux_armv6l.whl", hash = "sha256:064df58d84ccc0ac0fcd63bc3090b251d90e2a372558c0f057c3f75ed73e1ccd"},
+    {file = "ruff-0.6.9-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:140d4b5c9f5fc7a7b074908a78ab8d384dd7f6510402267bc76c37195c02a7ec"},
+    {file = "ruff-0.6.9-py3-none-macosx_11_0_arm64.whl", hash = "sha256:53fd8ca5e82bdee8da7f506d7b03a261f24cd43d090ea9db9a1dc59d9313914c"},
+    {file = "ruff-0.6.9-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:645d7d8761f915e48a00d4ecc3686969761df69fb561dd914a773c1a8266e14e"},
+    {file = "ruff-0.6.9-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:eae02b700763e3847595b9d2891488989cac00214da7f845f4bcf2989007d577"},
+    {file = "ruff-0.6.9-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7d5ccc9e58112441de8ad4b29dcb7a86dc25c5f770e3c06a9d57e0e5eba48829"},
+    {file = "ruff-0.6.9-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:417b81aa1c9b60b2f8edc463c58363075412866ae4e2b9ab0f690dc1e87ac1b5"},
+    {file = "ruff-0.6.9-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3c866b631f5fbce896a74a6e4383407ba7507b815ccc52bcedabb6810fdb3ef7"},
+    {file = "ruff-0.6.9-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7b118afbb3202f5911486ad52da86d1d52305b59e7ef2031cea3425142b97d6f"},
+    {file = "ruff-0.6.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a67267654edc23c97335586774790cde402fb6bbdb3c2314f1fc087dee320bfa"},
+    {file = "ruff-0.6.9-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:3ef0cc774b00fec123f635ce5c547dac263f6ee9fb9cc83437c5904183b55ceb"},
+    {file = "ruff-0.6.9-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:12edd2af0c60fa61ff31cefb90aef4288ac4d372b4962c2864aeea3a1a2460c0"},
+    {file = "ruff-0.6.9-py3-none-musllinux_1_2_i686.whl", hash = "sha256:55bb01caeaf3a60b2b2bba07308a02fca6ab56233302406ed5245180a05c5625"},
+    {file = "ruff-0.6.9-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:925d26471fa24b0ce5a6cdfab1bb526fb4159952385f386bdcc643813d472039"},
+    {file = "ruff-0.6.9-py3-none-win32.whl", hash = "sha256:eb61ec9bdb2506cffd492e05ac40e5bc6284873aceb605503d8494180d6fc84d"},
+    {file = "ruff-0.6.9-py3-none-win_amd64.whl", hash = "sha256:785d31851c1ae91f45b3d8fe23b8ae4b5170089021fbb42402d811135f0b7117"},
+    {file = "ruff-0.6.9-py3-none-win_arm64.whl", hash = "sha256:a9641e31476d601f83cd602608739a0840e348bda93fec9f1ee816f8b6798b93"},
+    {file = "ruff-0.6.9.tar.gz", hash = "sha256:b076ef717a8e5bc819514ee1d602bbdca5b4420ae13a9cf61a0c0a4f53a2baa2"},
+]
+
+[[package]]
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -1665,4 +1692,4 @@ watchdog = ["watchdog (>=2.3)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "9b7f9cbe53769a333d3362bc6ac5436411baf965c915e039021c8a9c3adcb686"
+content-hash = "0ab75e4aebd0cbf9ba93aed1973f8ba08ed22efb21efcfea65c617c5ed2849d6"

--- a/functions/pyproject.toml
+++ b/functions/pyproject.toml
@@ -27,6 +27,7 @@ google-auth-httplib2 = "^0.2.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.3"
+ruff = "^0.6.9"
 
 [build-system]
 requires = ["poetry-core"]

--- a/functions/src/shared/google_calendar_colors.py
+++ b/functions/src/shared/google_calendar_colors.py
@@ -53,3 +53,29 @@ class GoogleEventColor(str, Enum):
             "11": "dc2127",
         }
         return m[self.value]
+
+    def to_color_id(self) -> str:
+        match self:
+            case GoogleEventColor.LAVENDER:
+                return "1"
+            case GoogleEventColor.SAGE:
+                return "2"
+            case GoogleEventColor.GRAPE:
+                return "3"
+            case GoogleEventColor.TANGERINE:
+                return "4"
+            case GoogleEventColor.BANANA:
+                return "5"
+            case GoogleEventColor.FLAMINGO:
+                return "6"
+            case GoogleEventColor.PEACOCK:
+                return "7"
+            case GoogleEventColor.GRAPHITE:
+                return "8"
+            case GoogleEventColor.BLUEBERRY:
+                return "9"
+            case GoogleEventColor.BASIL:
+                return "10"
+            case GoogleEventColor.TOMATO:
+                return "11"
+        raise ValueError(f"Unknown color: {self}")

--- a/functions/tests/synchronizer/google_calendar_manager_test.py
+++ b/functions/tests/synchronizer/google_calendar_manager_test.py
@@ -1,0 +1,272 @@
+from datetime import datetime, timezone
+from unittest.mock import Mock
+
+import arrow
+from src.shared.event import Event
+from src.shared.google_calendar_colors import GoogleEventColor
+from src.synchronizer.google_calendar_manager import GoogleCalendarManager
+
+
+def test_event_to_google_event_basic():
+    # Arrange
+    service = Mock()
+    calendar_id = "test_calendar_id"
+    manager = GoogleCalendarManager(service, calendar_id)
+
+    event = Event(
+        start=arrow.get("2023-01-01T09:00:00+00:00"),
+        end=arrow.get("2023-01-01T10:00:00+00:00"),
+        title="Test Event",
+        description="Test Description",
+        location="Test Location",
+        color=None,
+    )
+    extended_properties = {"private": {"syncademic": "sync_profile_id"}}
+
+    # Act
+    google_event = manager.event_to_google_event(event, extended_properties)
+
+    # Assert
+    assert google_event == {
+        "summary": "Test Event",
+        "description": "Test Description",
+        "start": {"dateTime": "2023-01-01T09:00:00+00:00"},
+        "end": {"dateTime": "2023-01-01T10:00:00+00:00"},
+        "location": "Test Location",
+        "extendedProperties": extended_properties,
+    }
+
+
+def test_event_to_google_event_with_color():
+    # Arrange
+    service = Mock()
+    calendar_id = "test_calendar_id"
+    manager = GoogleCalendarManager(service, calendar_id)
+
+    color = GoogleEventColor.TOMATO
+
+    event = Event(
+        start=arrow.get("2023-01-01T09:00:00+00:00"),
+        end=arrow.get("2023-01-01T10:00:00+00:00"),
+        title="Colored Event",
+        description="Event with color",
+        location="Test Location",
+        color=color,
+    )
+    extended_properties = {"private": {"syncademic": "sync_profile_id"}}
+
+    # Act
+    google_event = manager.event_to_google_event(event, extended_properties)
+
+    # Assert
+    assert google_event == {
+        "summary": "Colored Event",
+        "description": "Event with color",
+        "start": {"dateTime": "2023-01-01T09:00:00+00:00"},
+        "end": {"dateTime": "2023-01-01T10:00:00+00:00"},
+        "location": "Test Location",
+        "extendedProperties": extended_properties,
+        "colorId": color.to_color_id(),
+    }
+
+
+def test_get_syncademic_marker():
+    # Arrange
+    service = Mock()
+    calendar_id = "test_calendar_id"
+    manager = GoogleCalendarManager(service, calendar_id)
+    sync_profile_id = "test_sync_profile"
+
+    # Act
+    marker = manager._get_syncademic_marker(sync_profile_id)
+
+    # Assert
+    assert marker == {"private": {"syncademic": sync_profile_id}}
+
+
+def test_create_events_successful():
+    # Arrange
+    service = Mock()
+    batch = Mock()
+    service.new_batch_http_request.return_value = batch
+    calendar_id = "test_calendar_id"
+    manager = GoogleCalendarManager(service, calendar_id)
+    sync_profile_id = "test_sync_profile"
+
+    event1 = Event(
+        start=arrow.get("2023-01-01T09:00:00+00:00"),
+        end=arrow.get("2023-01-01T10:00:00+00:00"),
+        title="Event 1",
+        description="Description 1",
+        location="Location 1",
+    )
+    event2 = Event(
+        start=arrow.get("2023-01-02T09:00:00+00:00"),
+        end=arrow.get("2023-01-02T10:00:00+00:00"),
+        title="Event 2",
+        description="Description 2",
+        location="Location 2",
+    )
+    events = [event1, event2]
+
+    # Act
+    manager.create_events(events, sync_profile_id)
+
+    # Assert
+    service.new_batch_http_request.assert_called_once()
+    assert batch.add.call_count == 2
+    batch.execute.assert_called_once()
+
+
+def test_create_events_in_batches():
+    # Arrange
+    service = Mock()
+    batch_calls = []
+
+    def new_batch_http_request():
+        batch = Mock()
+        batch_calls.append(batch)
+        return batch
+
+    service.new_batch_http_request.side_effect = new_batch_http_request
+
+    calendar_id = "test_calendar_id"
+    manager = GoogleCalendarManager(service, calendar_id)
+    sync_profile_id = "test_sync_profile"
+
+    n_events = 105
+    batch_size = 50
+
+    # Create more than 50 events to test batching
+    events = [
+        Event(
+            start=arrow.get(f"2023-01-{(i % 31) + 1:02d}T09:00:00+00:00"),
+            end=arrow.get(f"2023-01-{(i % 31) + 1:02d}T10:00:00+00:00"),
+            title=f"Event {i+1}",
+            description=f"Description {i+1}",
+            location=f"Location {i+1}",
+        )
+        for i in range(n_events)
+    ]
+
+    # Act
+    manager.create_events(
+        events,
+        sync_profile_id,
+        batch_size=batch_size,
+    )
+
+    # Assert
+    assert service.new_batch_http_request.call_count == n_events // batch_size + 1
+    total_add_calls = sum(batch.add.call_count for batch in batch_calls)
+    assert total_add_calls == n_events
+    total_execute_calls = sum(batch.execute.call_count for batch in batch_calls)
+    assert total_execute_calls == n_events // batch_size + 1
+
+
+def test_get_events_ids_from_sync_profile():
+    # Arrange
+    service = Mock()
+    calendar_id = "test_calendar_id"
+    manager = GoogleCalendarManager(service, calendar_id)
+    sync_profile_id = "test_sync_profile"
+    min_dt = datetime(2023, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+
+    # Mock the service.events().list().execute() chain
+    events_list = [{"id": "event_id_1"}, {"id": "event_id_2"}]
+    list_request = Mock()
+    list_request.execute.return_value = {"items": events_list}
+    service.events.return_value.list.return_value = list_request
+    service.events.return_value.list_next.return_value = None  # To end the loop
+
+    # Act
+    event_ids = manager.get_events_ids_from_sync_profile(
+        sync_profile_id,
+        min_dt,
+    )
+
+    # Assert
+    service.events.return_value.list.assert_called_once_with(
+        calendarId=calendar_id,
+        privateExtendedProperty=f"syncademic={sync_profile_id}",
+        singleEvents=True,
+        orderBy="startTime",
+        maxResults=1000,
+        timeMin=min_dt.isoformat(),
+    )
+    assert event_ids == ["event_id_1", "event_id_2"]
+
+
+def test_get_events_ids_from_sync_profile_multiple_pages():
+    # Arrange
+    service = Mock()
+    calendar_id = "test_calendar_id"
+    manager = GoogleCalendarManager(service, calendar_id)
+    sync_profile_id = "test_sync_profile"
+
+    # Mock the first page
+    events_page_1 = {"items": [{"id": "event_id_1"}]}
+    # Mock the second page
+    events_page_2 = {"items": [{"id": "event_id_2"}]}
+
+    request = Mock()
+    request.execute.side_effect = [events_page_1, events_page_2]
+    service.events.return_value.list.return_value = request
+    service.events.return_value.list_next.side_effect = [request, None]
+
+    # Act
+    event_ids = manager.get_events_ids_from_sync_profile(sync_profile_id)
+
+    # Assert
+    assert event_ids == ["event_id_1", "event_id_2"]
+
+
+def test_delete_events_successful():
+    # Arrange
+    service = Mock()
+    batch = Mock()
+    service.new_batch_http_request.return_value = batch
+    calendar_id = "test_calendar_id"
+    manager = GoogleCalendarManager(service, calendar_id)
+
+    event_ids = ["event_id_1", "event_id_2"]
+
+    # Act
+    manager.delete_events(event_ids)
+
+    # Assert
+    service.new_batch_http_request.assert_called_once()
+    assert batch.add.call_count == 2
+    batch.execute.assert_called_once()
+
+
+def test_delete_events_in_batches():
+    # Arrange
+    service = Mock()
+    batch_calls = []
+
+    def new_batch_http_request():
+        batch = Mock()
+        batch_calls.append(batch)
+        return batch
+
+    service.new_batch_http_request.side_effect = new_batch_http_request
+
+    calendar_id = "test_calendar_id"
+    manager = GoogleCalendarManager(service, calendar_id)
+
+    # Create more than 50 event IDs to test batching
+    n_events = 105
+    batch_size = 50
+
+    event_ids = [f"event_id_{i}" for i in range(n_events)]
+
+    # Act
+    manager.delete_events(event_ids, batch_size=batch_size)
+
+    # Assert
+    assert service.new_batch_http_request.call_count == 3  # 105 events / 50 per batch
+    total_add_calls = sum(batch.add.call_count for batch in batch_calls)
+    assert total_add_calls == 105
+    total_execute_calls = sum(batch.execute.call_count for batch in batch_calls)
+    assert total_execute_calls == 3


### PR DESCRIPTION
This PR implements tests to the GoogleCalendarManager class.
This allowed us to fix a bug introduced in the last PR, where we would pass the color names instead of their ids to Google calendar API, which resulted in a silent failure to create the events.