### PR TITLE
Read rules definition from db and apply them on sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ The backend is built on Firebase Cloud Functions.
     - `title` (string): The title of the target calendar, given by the calendar provider.
     - `description` (string): The description of the target calendar, given by the calendar provider.
     - `providerAccountId` (string): This is the unique identifier for the account that owns the target calendar. It is not the same as the Firebase Auth ID used in our app. Currently, this ID represents a Google account, but in the future, it could also represent accounts from other providers like Microsoft. This distinction is important because a single user of our app can manage multiple synchronization profiles, each targeting calendars owned by different accounts across various providers.
+  - `ruleset` (string): A valid JSON string a Ruleset to apply.
 
 ### `backendAuthorizations` collection
 

--- a/functions/functions/synchronizer/synchronizer.py
+++ b/functions/functions/synchronizer/synchronizer.py
@@ -21,13 +21,13 @@ def perform_synchronization(
     ics_cache: IcsFileStorage,
     calendar_manager: GoogleCalendarManager,
     middlewares: Optional[List[Middleware]] = None,
-    rule_set: Ruleset | None = None,
+    ruleset: Ruleset | None = None,
     separation_dt: datetime | None = None,
     sync_type: SyncType = "regular",
 ) -> None:
     # Temporary : only one of middlewares or ruleset can be provided, not both
     assert not (
-        middlewares and rule_set
+        middlewares and ruleset
     ), "Only one of middlewares or ruleset can be provided"
 
     try:
@@ -67,9 +67,9 @@ def perform_synchronization(
         raise e
 
     try:
-        if rule_set:
-            logger.info(f"Applying {len(rule_set.rules)} rules")
-            events = rule_set.apply(events)
+        if ruleset:
+            logger.info(f"Applying {len(ruleset.rules)} rules")
+            events = ruleset.apply(events)
             logger.info(f"{len(events)} events after applying rules")
     except Exception as e:
         logger.error(f"Failed to apply rules: {e}")

--- a/functions/tests/synchronizer/synchronizer_test.py
+++ b/functions/tests/synchronizer/synchronizer_test.py
@@ -240,7 +240,7 @@ def test_perform_synchronization_with_ruleset():
         ics_parser=ics_parser,
         ics_cache=ics_cache,
         calendar_manager=calendar_manager,
-        rule_set=ruleset,
+        ruleset=ruleset,
     )
 
     # Assert
@@ -325,7 +325,7 @@ def test_perform_synchronization_no_events_after_ruleset():
         ics_parser=ics_parser,
         ics_cache=ics_cache,
         calendar_manager=calendar_manager,
-        rule_set=ruleset,
+        ruleset=ruleset,
     )
 
     # Assert
@@ -406,7 +406,7 @@ def test_perform_synchronization_both_middlewares_and_ruleset():
             ics_cache=ics_cache,
             calendar_manager=calendar_manager,
             middlewares=middlewares,
-            rule_set=ruleset,
+            ruleset=ruleset,
         )
 
 
@@ -657,7 +657,7 @@ def test_perform_synchronization_with_ruleset_full_sync():
         ics_parser=ics_parser,
         ics_cache=ics_cache,
         calendar_manager=calendar_manager,
-        rule_set=ruleset,
+        ruleset=ruleset,
         sync_type="full",
     )
 


### PR DESCRIPTION
On each synchronization, Syncademic will now read the rules definition from `<syncProfileDocument>.ruleset` and apply them. 
If there no rules, then it applies middlewares. In the future, we will completely remove the middlewares once the AI can produce valid and useful rules automatically