### PR TITLE
Restrict ICS size and Synchronizations frequency

### DIFF
--- a/functions/functions/settings.py
+++ b/functions/functions/settings.py
@@ -20,7 +20,7 @@ class Settings(BaseSettings):
 
     MAX_ICS_SIZE_CHARS: int = Field(default=1_000_000)
     MAX_SYNCHRONIZATIONS_PER_DAY: int = Field(
-        default=30  # Approx 1 per hour plus some manual ones.
+        default=24 * 5  # 24 syncs per day for 5 profiles
     )
 
 

--- a/functions/functions/settings.py
+++ b/functions/functions/settings.py
@@ -19,6 +19,9 @@ class Settings(BaseSettings):
     PRODUCTION_REDIRECT_URI: str = Field(default=...)
 
     MAX_ICS_SIZE_CHARS: int = Field(default=1_000_000)
+    MAX_SYNCHRONIZATIONS_PER_DAY: int = Field(
+        default=30  # Approx 1 per hour plus some manual ones.
+    )
 
 
 settings = Settings()

--- a/functions/functions/settings.py
+++ b/functions/functions/settings.py
@@ -1,5 +1,8 @@
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from pydantic import Field
+import os
+
+IGNORE_ON_GITHUB_ACTIONS = "" if os.getenv("GITHUB_ACTIONS") else ...
 
 
 class Settings(BaseSettings):
@@ -12,11 +15,11 @@ class Settings(BaseSettings):
 
     RULES_BUILDER_LLM: str = Field(default="gpt-4o")
 
-    CLIENT_ID: str = Field(default=...)
-    CLIENT_SECRET: str = Field(default=...)
+    CLIENT_ID: str = Field(default=IGNORE_ON_GITHUB_ACTIONS)
+    CLIENT_SECRET: str = Field(default=IGNORE_ON_GITHUB_ACTIONS)
 
-    LOCAL_REDIRECT_URI: str = Field(default=...)
-    PRODUCTION_REDIRECT_URI: str = Field(default=...)
+    LOCAL_REDIRECT_URI: str = Field(default=IGNORE_ON_GITHUB_ACTIONS)
+    PRODUCTION_REDIRECT_URI: str = Field(default=IGNORE_ON_GITHUB_ACTIONS)
 
     MAX_ICS_SIZE_CHARS: int = Field(default=1_000_000)
     MAX_SYNCHRONIZATIONS_PER_DAY: int = Field(

--- a/functions/functions/settings.py
+++ b/functions/functions/settings.py
@@ -18,6 +18,8 @@ class Settings(BaseSettings):
     LOCAL_REDIRECT_URI: str = Field(default=...)
     PRODUCTION_REDIRECT_URI: str = Field(default=...)
 
+    MAX_ICS_SIZE_CHARS: int = Field(default=1_000_000)
+
 
 settings = Settings()
 

--- a/functions/functions/synchronizer/synchronizer.py
+++ b/functions/functions/synchronizer/synchronizer.py
@@ -29,6 +29,7 @@ def perform_synchronization(
     ruleset: Ruleset | None = None,
     separation_dt: datetime | None = None,
     sync_type: SyncType = "regular",
+    max_ics_size_chars: int = settings.MAX_ICS_SIZE_CHARS,
 ) -> None:
     # Temporary : only one of middlewares or ruleset can be provided, not both
     assert not (
@@ -42,9 +43,9 @@ def perform_synchronization(
         raise e
 
     # Check size of ics string
-    if len(ics_str) > settings.MAX_ICS_SIZE_CHARS:
+    if len(ics_str) > max_ics_size_chars:
         logger.error(
-            f"ICS string is too large: {len(ics_str)} > {settings.MAX_ICS_SIZE_CHARS} chars"
+            f"ICS string is too large: {len(ics_str)} > {max_ics_size_chars} chars"
         )
         raise ValueError("ICS file is too large")
 

--- a/functions/main.py
+++ b/functions/main.py
@@ -518,7 +518,7 @@ def _synchronize_now(
             },
         }
     )
-    sync_stats_ref.set({"syncCount": sync_count + 1}, merge=True)
+    sync_stats_ref.set({"syncCount": firestore.firestore.Increment(1)}, merge=True)
 
     logger.info("Synchronization completed successfully")
 

--- a/functions/tests/synchronizer/synchronizer_test.py
+++ b/functions/tests/synchronizer/synchronizer_test.py
@@ -12,7 +12,6 @@ from functions.rules.models import (
     Ruleset,
     TextFieldCondition,
 )
-from functions.settings import settings
 from functions.shared.event import Event
 from functions.shared.google_calendar_colors import GoogleEventColor
 from functions.synchronizer.google_calendar_manager import GoogleCalendarManager
@@ -690,11 +689,10 @@ def test_perform_synchronization_ics_too_large():
     # Arrange
     sync_profile_id = "test_sync_profile"
     sync_trigger = "manual"
+    MAX_ICS_SIZE_CHARS = 1000
 
     # Create a large ICS string exceeding MAX_ICS_SIZE_CHARS
-    ics_str = (
-        "BEGIN:VCALENDAR\n" + "A" * (settings.MAX_ICS_SIZE_CHARS) + "\nEND:VCALENDAR"
-    )
+    ics_str = "BEGIN:VCALENDAR\n" + "A" * (MAX_ICS_SIZE_CHARS) + "\nEND:VCALENDAR"
 
     # Mock ICS source
     ics_source = Mock(spec=UrlIcsSource)
@@ -714,6 +712,7 @@ def test_perform_synchronization_ics_too_large():
             ics_parser=ics_parser,
             ics_cache=ics_cache,
             calendar_manager=calendar_manager,
+            max_ics_size_chars=MAX_ICS_SIZE_CHARS,
         )
 
     # Verify that get_ics_string was called


### PR DESCRIPTION
This PR adds some limits in the system to prevent abuse, such as limit the number of synchronizations per day, and the whole size of an ICS file. 