### PR TITLE
raise if recurring events in ICS

### DIFF
--- a/functions/functions/synchronizer/google_calendar_manager.py
+++ b/functions/functions/synchronizer/google_calendar_manager.py
@@ -112,6 +112,8 @@ class GoogleCalendarManager:
             events_as_dict.extend(response.get("items", []))
             request = self.service.events().list_next(request, response)
 
+        # TODO : assert here that the API respected timeMin
+
         return [event["id"] for event in events_as_dict]
 
     def delete_events(

--- a/functions/functions/synchronizer/ics_parser.py
+++ b/functions/functions/synchronizer/ics_parser.py
@@ -4,19 +4,53 @@ from functions.shared.event import Event
 import ics
 
 
+class RecurringEventError(Exception):
+    """Custom exception raised when a recurring event is detected because we don't support them yet."""
+
+    pass
+
+
+def check_for_recurring_event(event) -> None:
+    """
+    Check if an event contains recurrence properties and raise RecurringEventError if found.
+
+    Args:
+        event: The ICS event to check
+
+    Raises:
+        RecurringEventError: If the event contains any recurrence properties
+    """
+    extra_names: list[str] = [extra.name for extra in event.extra]
+    assert all(isinstance(name, str) for name in extra_names)
+
+    if any(
+        extra_name.startswith(prop)
+        for extra_name in extra_names
+        for prop in ["RRULE", "RDATE", "EXDATE"]
+    ):
+        raise RecurringEventError(
+            f"Recurring event detected: {event.name=}, {extra_names=}. We do not support recurring events yet."
+        )
+
+
 class IcsParser:
     def __init__(self):
         pass
 
     def parse(self, ics_str: str) -> List[Event]:
         calendar = ics.Calendar(ics_str)
-        return [
-            Event(
-                title=event.name or "",
-                description=event.description or "",
-                start=event.begin,
-                end=event.end,
-                location=event.location or "",
+        events = []
+        for event in calendar.events:
+            check_for_recurring_event(event)
+
+            # Append non-recurring events to the list
+            events.append(
+                Event(
+                    title=event.name or "",
+                    description=event.description or "",
+                    start=event.begin,
+                    end=event.end,
+                    location=event.location or "",
+                )
             )
-            for event in calendar.events
-        ]
+        return events

--- a/functions/tests/synchronizer/ics_parser_test.py
+++ b/functions/tests/synchronizer/ics_parser_test.py
@@ -2,7 +2,7 @@ import pytest
 from typing import List
 import arrow
 from functions.shared.event import Event
-from functions.synchronizer.ics_parser import IcsParser
+from functions.synchronizer.ics_parser import IcsParser, RecurringEventError
 
 
 def build_ics_outline(inside: str):
@@ -185,4 +185,46 @@ DTEND:20230101T090000
 END:VEVENT"""
     )
     with pytest.raises(Exception):
+        ics_parser.parse(ics_str)
+
+
+def test_recurring_event_with_rrule_throws(ics_parser):
+    """Test that a recurring event with RRULE raises an error. We do not support recurring events yet."""
+    ics_str = build_ics_outline(
+        """BEGIN:VEVENT
+SUMMARY:Recurring Event
+DTSTART:20230101T090000
+DTEND:20230101T100000
+RRULE:FREQ=DAILY;COUNT=5
+END:VEVENT"""
+    )
+    with pytest.raises(RecurringEventError):
+        ics_parser.parse(ics_str)
+
+
+def test_recurring_event_with_rdate_throws(ics_parser):
+    """Test that a recurring event with RDATE raises an error. We do not support recurring events yet."""
+    ics_str = build_ics_outline(
+        """BEGIN:VEVENT
+SUMMARY:Recurring Event
+DTSTART:20230101T090000
+DTEND:20230101T100000
+RDATE:20230102T090000,20230103T090000
+END:VEVENT"""
+    )
+    with pytest.raises(RecurringEventError):
+        ics_parser.parse(ics_str)
+
+
+def test_recurring_event_with_exdate_throws(ics_parser):
+    """Test that a recurring event with EXDATE raises an error. We do not support recurring events yet."""
+    ics_str = build_ics_outline(
+        """BEGIN:VEVENT
+SUMMARY:Recurring Event
+DTSTART:20230101T090000
+DTEND:20230101T100000
+EXDATE:20230102T090000
+END:VEVENT"""
+    )
+    with pytest.raises(RecurringEventError):
         ics_parser.parse(ics_str)


### PR DESCRIPTION
If there are recurring events in the ICS file of a synchronization, raise an error. I never encountered an academic ICS with recurring events, so I want to take time to analyze the matter before allowing users to provide such ICS.