### PR TITLE
Better ics file size restriction

### DIFF
--- a/functions/functions/settings.py
+++ b/functions/functions/settings.py
@@ -2,7 +2,18 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 from pydantic import Field
 import os
 
-IGNORE_ON_GITHUB_ACTIONS = "" if os.getenv("GITHUB_ACTIONS") else ...
+
+# This is a workaround to avoid setting the variables
+# are optional or providing default values. This way,
+# we ensure that the variables are always set in other
+# environments.
+IGNORE_ON_GITHUB_ACTIONS = "" if (os.getenv("GITHUB_ACTIONS")) else ...
+
+
+# Making the variables required causes VSCode's
+# test discovery to fail. To solve this, we provide
+# default testing values to required variables
+# in pyproject.toml using pytest-env.
 
 
 class Settings(BaseSettings):

--- a/functions/functions/settings.py
+++ b/functions/functions/settings.py
@@ -21,7 +21,8 @@ class Settings(BaseSettings):
     LOCAL_REDIRECT_URI: str = Field(default=IGNORE_ON_GITHUB_ACTIONS)
     PRODUCTION_REDIRECT_URI: str = Field(default=IGNORE_ON_GITHUB_ACTIONS)
 
-    MAX_ICS_SIZE_CHARS: int = Field(default=1_000_000)
+    MAX_ICS_SIZE_BYTES: int = Field(default=1 * 1024 * 1024)  # 1 MB
+
     MAX_SYNCHRONIZATIONS_PER_DAY: int = Field(
         default=24 * 5  # 24 syncs per day for 5 profiles
     )

--- a/functions/functions/synchronizer/ics_cache.py
+++ b/functions/functions/synchronizer/ics_cache.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 from datetime import datetime, timezone
+from typing import Any
 from functions.synchronizer.ics_source import UrlIcsSource
 from google.cloud import storage
 from firebase_functions import logger
@@ -13,9 +14,20 @@ class IcsFileStorage(ABC):
         sync_trigger: str,
         ics_source: UrlIcsSource,
         ics_str: str,
-        parsing_error: str | None = None,
+        parsing_error: str | Exception | None = None,
     ) -> None:
         pass
+
+
+def format_exception(e: Any) -> str | dict | None:
+    if not e:
+        return None
+    if isinstance(e, Exception):
+        return {
+            "type": type(e).__name__,
+            "message": str(e),
+        }
+    return str(e)
 
 
 class FirebaseIcsFileStorage(IcsFileStorage):
@@ -28,7 +40,7 @@ class FirebaseIcsFileStorage(IcsFileStorage):
         sync_trigger: str,  # TODO : type this
         ics_source: UrlIcsSource,
         ics_str: str,
-        parsing_error: str | None = None,
+        parsing_error: str | Exception | None = None,
     ) -> None:
         now = datetime.now(timezone.utc)
 
@@ -40,7 +52,7 @@ class FirebaseIcsFileStorage(IcsFileStorage):
             "syncProfileId": sync_profile_id,
             "syncTrigger": sync_trigger,
             "blob_created_at": now.isoformat(),
-            "parsing_error": parsing_error,
+            "parsing_error": format_exception(parsing_error),
         }
         blob.upload_from_string(ics_str, content_type="text/calendar")
         logger.info(f"Stored ics string in firebase storage: {filename}")

--- a/functions/functions/synchronizer/ics_source.py
+++ b/functions/functions/synchronizer/ics_source.py
@@ -46,7 +46,7 @@ class UrlIcsSource(IcsSource):
                     content_length = int(content_length)
                     if content_length > self.max_content_size_b:
                         logger.info(
-                            f"Content-Length is too large. ({response.headers=})"
+                            f"Content-Length is too large ({content_length/1_048_576:.2f}MB > {self.max_content_size_b/1_048_576:.2f}MB) ({response.headers=})"
                         )
                         raise ValueError("ICS file is too large.")
 

--- a/functions/functions/synchronizer/ics_source.py
+++ b/functions/functions/synchronizer/ics_source.py
@@ -65,6 +65,7 @@ class UrlIcsSource(IcsSource):
                 return chunks.getvalue().decode("utf-8", errors="ignore")
 
         except requests.RequestException as e:
+            logger.error(f"Could not fetch ICS file : {e}")
             raise ValueError(f"Could not fetch ICS file : {e}")
 
 

--- a/functions/functions/synchronizer/ics_source.py
+++ b/functions/functions/synchronizer/ics_source.py
@@ -1,7 +1,10 @@
 from abc import ABC, abstractmethod
+import io
+from functions.settings import settings
 import validators
 from pathlib import Path
 import requests
+from firebase_functions import logger
 
 
 class IcsSource(ABC):
@@ -11,25 +14,58 @@ class IcsSource(ABC):
 
 
 class UrlIcsSource(IcsSource):
-    def __init__(self, url: str):
+    def __init__(
+        self,
+        url: str,
+        timeout_s: int = 10,
+        max_content_size_b: int = settings.MAX_ICS_SIZE_BYTES,
+    ):
         if not validators.url(url):
             raise ValueError("Invalid URL")
         self.url = url
+        self.timeout_s = timeout_s
+        self.max_content_size_b = max_content_size_b
 
     def get_ics_string(self) -> str:
-        # TODO : check content_type
+        logger.info(f"Fetching ICS file from {self.url}")
         try:
-            response = requests.get(self.url)
-            response.raise_for_status()
+            with requests.get(
+                self.url, stream=True, timeout=self.timeout_s
+            ) as response:
+                response.raise_for_status()
+
+                # Check the Content-Type header
+                content_type = response.headers.get("Content-Type")
+                if content_type is not None and "text" not in content_type:
+                    logger.info(f"Content-Type is not text : {content_type}")
+                    raise ValueError(f"Content-Type is not text : {content_type}")
+
+                # Check the Content-Length header if available
+                content_length = response.headers.get("Content-Length")
+                if content_length is not None:
+                    content_length = int(content_length)
+                    if content_length > self.max_content_size_b:
+                        logger.info(
+                            f"Content-Length is too large. ({response.headers=})"
+                        )
+                        raise ValueError("ICS file is too large.")
+
+                # Use BytesIO to accumulate chunks
+                chunks = io.BytesIO()
+                total_bytes = 0
+
+                # Collect raw bytes first
+                for chunk in response.iter_content(chunk_size=8192):
+                    total_bytes += len(chunk)
+                    if total_bytes > self.max_content_size_b:
+                        raise ValueError("ICS file is too large.")
+                    chunks.write(chunk)
+
+                # Decode all bytes at once
+                return chunks.getvalue().decode("utf-8", errors="ignore")
+
         except requests.RequestException as e:
-            raise ValueError(f"Could not fetch ics file from internet: {e}")
-
-        # For testing purpose, we want to download ics files from github, which is not a calendar file.
-        # So we don't check the content type for now.
-        # if "text/calendar" not in response.headers["Content-Type"]:
-        #     raise ValueError(f"Content type is {response.headers['Content-Type']}")
-
-        return response.text
+            raise ValueError(f"Could not fetch ICS file : {e}")
 
 
 class FileIcsSource(IcsSource):

--- a/functions/functions/synchronizer/synchronizer.py
+++ b/functions/functions/synchronizer/synchronizer.py
@@ -5,12 +5,11 @@ from typing import List, Literal, Optional
 from firebase_functions import logger
 
 from functions.rules.models import Ruleset
-from functions.settings import settings
 from functions.shared.google_calendar_colors import GoogleEventColor
 from functions.synchronizer.ics_cache import IcsFileStorage
 
 from .google_calendar_manager import GoogleCalendarManager
-from .ics_parser import IcsParser, RecurringEventError
+from .ics_parser import IcsParser
 from .ics_source import UrlIcsSource
 from .middleware.middleware import Middleware
 
@@ -35,11 +34,7 @@ def perform_synchronization(
         middlewares and ruleset
     ), "Only one of middlewares or ruleset can be provided"
 
-    try:
-        ics_str = ics_source.get_ics_string()
-    except Exception as e:
-        logger.error(f"Failed to get ics string: {e}")
-        raise e
+    ics_str = ics_source.get_ics_string()
 
     try:
         events = ics_parser.parse(ics_str)
@@ -50,7 +45,7 @@ def perform_synchronization(
             sync_trigger=sync_trigger,
             ics_source=ics_source,
             ics_str=ics_str,
-            parsing_error=str(e),
+            parsing_error=e,
         )
         raise e
 

--- a/functions/functions/synchronizer/synchronizer.py
+++ b/functions/functions/synchronizer/synchronizer.py
@@ -29,7 +29,6 @@ def perform_synchronization(
     ruleset: Ruleset | None = None,
     separation_dt: datetime | None = None,
     sync_type: SyncType = "regular",
-    max_ics_size_chars: int = settings.MAX_ICS_SIZE_CHARS,
 ) -> None:
     # Temporary : only one of middlewares or ruleset can be provided, not both
     assert not (
@@ -41,13 +40,6 @@ def perform_synchronization(
     except Exception as e:
         logger.error(f"Failed to get ics string: {e}")
         raise e
-
-    # Check size of ics string
-    if len(ics_str) > max_ics_size_chars:
-        logger.error(
-            f"ICS string is too large: {len(ics_str)} > {max_ics_size_chars} chars"
-        )
-        raise ValueError("ICS file is too large")
 
     try:
         events = ics_parser.parse(ics_str)

--- a/functions/main.py
+++ b/functions/main.py
@@ -1,4 +1,3 @@
-import logging
 import os
 from datetime import datetime, timezone
 from typing import Any
@@ -215,10 +214,10 @@ def create_new_calendar(req: https_fn.CallableRequest) -> dict:
 def _create_ai_ruleset(sync_profile_ref: DocumentReference):
     logger.info(f"Creating AI ruleset for {sync_profile_ref.path}")
 
-    llm = settings.RULES_BUILDER_LLM
+    model = settings.RULES_BUILDER_LLM
 
-    logger.info(f"Using {llm} model")
-    gpt4o = init_chat_model(llm)
+    logger.info(f"Using {model} model")
+    llm = init_chat_model(model)
 
     doc = sync_profile_ref.get()
     if not doc.exists:
@@ -238,7 +237,7 @@ def _create_ai_ruleset(sync_profile_ref: DocumentReference):
 
     logger.info(f"Creating AI ruleset for {sync_profile_ref.path}")
 
-    ruleset_builder = RulesetBuilder(llm=gpt4o)
+    ruleset_builder = RulesetBuilder(llm=llm)
 
     output = ruleset_builder.generate_ruleset(
         compressed_schedule,
@@ -257,7 +256,7 @@ def _create_ai_ruleset(sync_profile_ref: DocumentReference):
     max_instances=settings.MAX_CLOUD_FUNCTIONS_INSTANCES,
 )  # type: ignore
 def on_sync_profile_created(event: Event[DocumentSnapshot]):
-    logging.info(f"Sync profile created: {event.data}")
+    logger.info(f"Sync profile created: {event.data}")
 
     doc = event.data.to_dict()
 

--- a/functions/poetry.lock
+++ b/functions/poetry.lock
@@ -2522,6 +2522,23 @@ pluggy = ">=1.5,<2"
 dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
+name = "pytest-env"
+version = "1.1.5"
+description = "pytest plugin that allows you to add environment variables."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pytest_env-1.1.5-py3-none-any.whl", hash = "sha256:ce90cf8772878515c24b31cd97c7fa1f4481cd68d588419fd45f10ecaee6bc30"},
+    {file = "pytest_env-1.1.5.tar.gz", hash = "sha256:91209840aa0e43385073ac464a554ad2947cc2fd663a9debf88d03b01e0cc1cf"},
+]
+
+[package.dependencies]
+pytest = ">=8.3.3"
+
+[package.extras]
+testing = ["covdefaults (>=2.3)", "coverage (>=7.6.1)", "pytest-mock (>=3.14)"]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 description = "Extensions to the standard Python datetime module"
@@ -2777,6 +2794,25 @@ files = [
 
 [package.dependencies]
 requests = ">=2.0.1,<3.0.0"
+
+[[package]]
+name = "responses"
+version = "0.25.3"
+description = "A utility library for mocking out the `requests` Python library."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "responses-0.25.3-py3-none-any.whl", hash = "sha256:521efcbc82081ab8daa588e08f7e8a64ce79b91c39f6e62199b19159bea7dbcb"},
+    {file = "responses-0.25.3.tar.gz", hash = "sha256:617b9247abd9ae28313d57a75880422d55ec63c29d33d629697590a034358dba"},
+]
+
+[package.dependencies]
+pyyaml = "*"
+requests = ">=2.30.0,<3.0"
+urllib3 = ">=1.25.10,<3.0"
+
+[package.extras]
+tests = ["coverage (>=6.0.0)", "flake8", "mypy", "pytest (>=7.0.0)", "pytest-asyncio", "pytest-cov", "pytest-httpserver", "tomli", "tomli-w", "types-PyYAML", "types-requests"]
 
 [[package]]
 name = "rsa"
@@ -3483,4 +3519,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "c126be5a728bb7e51d3ee5a764373aaf373089350727842cde82417eca1d7a4e"
+content-hash = "7ca6df9a09dc1aa9bb0412096daf37e26c055a7c4ce9c417b96b3369fbe5761e"

--- a/functions/pyproject.toml
+++ b/functions/pyproject.toml
@@ -36,7 +36,22 @@ langchain-anthropic = "^0.2.3"
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.3"
 ruff = "^0.6.9"
+responses = "^0.25.3"
+pytest-env = "^1.1.5"
 
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+
+[tool.pytest.ini_options]
+# These variables will be set during testing.
+# This prevents the test discovery from failing
+# due to missing environment variables in settings.py
+env = [
+    "CLIENT_ID=test-client-id",
+    "CLIENT_SECRET=test-client-secret",
+    "LOCAL_REDIRECT_URI=http://localhost:8080",
+    "PRODUCTION_REDIRECT_URI=https://example.com",
+]
+

--- a/functions/tests/synchronizer/ics_source_test.py
+++ b/functions/tests/synchronizer/ics_source_test.py
@@ -1,0 +1,196 @@
+import pytest
+import requests
+import responses
+
+from functions.settings import settings
+from functions.synchronizer.ics_source import UrlIcsSource
+
+# Mock settings
+settings.MAX_ICS_SIZE_BYTES = 1 * 1024 * 1024  # 1 MB
+
+# Sample ICS content
+valid_ics_content = """
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Your Organization//Your Product//EN
+BEGIN:VEVENT
+UID:123456
+DTSTAMP:20240101T120000Z
+DTSTART:20240101T130000Z
+DTEND:20240101T140000Z
+SUMMARY:Test Event
+END:VEVENT
+END:VCALENDAR
+"""
+
+large_ics_content = "A" * (settings.MAX_ICS_SIZE_BYTES + 1)  # Just over 1 MB
+
+invalid_content_type = "This is not ICS content"
+
+invalid_url = "htp:/invalid-url"
+
+
+def test_valid_ics_url_with_content_length():
+    url = "https://example.com/valid.ics"
+
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            responses.GET,
+            url,
+            body=valid_ics_content,
+            status=200,
+            content_type="text/calendar",
+            adding_headers={"Content-Length": str(len(valid_ics_content))},
+        )
+
+        ics_source = UrlIcsSource(url)
+        ics_string = ics_source.get_ics_string()
+        assert ics_string == valid_ics_content
+
+
+def test_valid_ics_url_without_content_length():
+    url = "https://example.com/valid.ics"
+
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            responses.GET,
+            url,
+            body=valid_ics_content,
+            status=200,
+            content_type="text/calendar",
+            # No Content-Length header
+        )
+
+        ics_source = UrlIcsSource(url)
+        ics_string = ics_source.get_ics_string()
+        assert ics_string == valid_ics_content
+
+
+def test_ics_file_too_large_with_content_length():
+    url = "https://example.com/large.ics"
+
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            responses.GET,
+            url,
+            body=large_ics_content,
+            status=200,
+            content_type="text/calendar",
+            adding_headers={"Content-Length": str(len(large_ics_content))},
+        )
+
+        ics_source = UrlIcsSource(url)
+        with pytest.raises(ValueError, match="ICS file is too large"):
+            ics_source.get_ics_string()
+
+
+def test_ics_file_too_large_without_content_length():
+    url = "https://example.com/large.ics"
+
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            responses.GET,
+            url,
+            body=large_ics_content,
+            status=200,
+            content_type="text/calendar",
+            # No Content-Length header
+        )
+
+        ics_source = UrlIcsSource(url)
+        with pytest.raises(ValueError, match="ICS file is too large"):
+            ics_source.get_ics_string()
+
+
+def test_http_error():
+    url = "https://example.com/notfound.ics"
+
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            responses.GET, url, body="Not Found", status=404, content_type="text/plain"
+        )
+
+        ics_source = UrlIcsSource(url)
+        with pytest.raises(ValueError, match="Could not fetch ICS file"):
+            ics_source.get_ics_string()
+
+
+def test_invalid_content_type():
+    url = "https://example.com/invalid-content-type.ics"
+
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            responses.GET,
+            url,
+            body=valid_ics_content,
+            status=200,
+            content_type="application/pdf",
+            adding_headers={"Content-Length": str(len(valid_ics_content))},
+        )
+
+        ics_source = UrlIcsSource(url)
+        with pytest.raises(ValueError, match="Content-Type is not text"):
+            ics_source.get_ics_string()
+
+
+def test_missing_content_type():
+    url = "https://example.com/valid.ics"
+
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            responses.GET,
+            url,
+            body=valid_ics_content,
+            status=200,
+            adding_headers={"Content-Length": str(len(valid_ics_content))},
+        )
+
+        ics_source = UrlIcsSource(url)
+        ics_string = ics_source.get_ics_string()
+        assert ics_string == valid_ics_content
+
+
+@pytest.mark.parametrize(
+    "content_type",
+    ["text/calendar", "text/plain"],
+)
+def test_valid_content_type(content_type):
+    url = "https://example.com/valid.ics"
+
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            responses.GET,
+            url,
+            body=valid_ics_content,
+            status=200,
+            content_type=content_type,
+            adding_headers={"Content-Length": str(len(valid_ics_content))},
+        )
+
+        ics_source = UrlIcsSource(url)
+        ics_string = ics_source.get_ics_string()
+        assert ics_string == valid_ics_content
+
+
+def test_invalid_url():
+    url = invalid_url
+
+    with pytest.raises(ValueError, match="Invalid URL"):
+        UrlIcsSource(url)
+
+
+def test_timeout():
+    url = "https://example.com/timeout.ics"
+
+    with responses.RequestsMock() as rsps:
+
+        def request_callback(request):
+            raise requests.exceptions.Timeout()
+
+        rsps.add_callback(
+            responses.GET, url, callback=request_callback, content_type="text/calendar"
+        )
+
+        ics_source = UrlIcsSource(url)
+        with pytest.raises(ValueError, match="Could not fetch ICS file"):
+            ics_source.get_ics_string()


### PR DESCRIPTION
Syncademic needs to automatically download ICS files from schools and university servers, using URLs provided by users. This introduces an abuse vector, as users could provide urls towards huge files on purpose, increasing latency and costs. 

We thus want to restrict the size of ICS files downloaded by the backend. 

Downloads occur in at least two steps :

- Initially validating the ICS url, verifying that it points to a publicly accessible and valid ICS file.
- On every subsequent synchronizations

Currently, the way to download the ICS files is by using this simple class 

```python
from abc import ABC, abstractmethod
import validators
from pathlib import Path
import requests

class IcsSource(ABC):
    @abstractmethod
    def get_ics_string(self) -> str:
        pass

class UrlIcsSource(IcsSource):
    def __init__(self, url: str):
        if not validators.url(url):
            raise ValueError("Invalid URL")
        self.url = url

    def get_ics_string(self) -> str:
        # TODO : check content_type
        try:
            response = requests.get(self.url)
            response.raise_for_status()
        except requests.RequestException as e:
            raise ValueError(f"Could not fetch ics file from internet: {e}")

        # For testing purpose, we want to download ics files from github, which is not a calendar file.
        # So we don't check the content type for now.
        # if "text/calendar" not in response.headers["Content-Type"]:
        #     raise ValueError(f"Content type is {response.headers['Content-Type']}")

        return response.text
```

This has a major flaw : if the URL points to a huge file, the backend will entirely download it before crashing or returning an error. 

What we want is to immediately discard huge files while or before downloading them.


This PR implements file size restriction logic, by first checking at the Content-Length header, and cancelling download if file exceed size. 

We also implement again the Content-Type header verification, allowing only text files. 