### PR TITLE
Store and display targetCalendar.providerAccountEmail

### DIFF
--- a/dev/docs/firestore.md
+++ b/dev/docs/firestore.md
@@ -26,6 +26,7 @@
     - `title` (string): Title of the target calendar, provided by the calendar provider.
     - `description` (string): Description of the target calendar, provided by the calendar provider.
     - `providerAccountId` (string): Unique identifier for the account owning the target calendar (e.g., Google account ID).
+    - `providerAccountEmail` (string): Email of the account owning the target calendar.
   - `ruleset` (string, optional): JSON string of a `Ruleset` to apply.
   - `ruleset_error` (string, optional): Error message if generating the ruleset failed.
   - `created_at` (timestamp): Timestamp when the sync profile was created.

--- a/dev/docs/firestore.md
+++ b/dev/docs/firestore.md
@@ -2,44 +2,51 @@
 
 ### `users` collection
 
+**ID**: Firebase Auth ID.
+
 **Fields**
 
-- `id` (string): Firebase Auth ID
-- `email` (string): Email of the user, given by Firebase Auth
+- `email` (string, optional): Email of the user. (Currently unsecured as it's provided by the frontend. Use data in FirebaseAuth instead.)
 
 **Subcollections**
 
-- `SyncProfiles` // Consider moving this to a root collection
+- #### `syncProfiles`
 
   **Fields**
 
   - `title` (string)
   - `scheduleSource` (map)
-    - `url` (string): URL that points to an ICS file
+    - `url` (string): URL pointing to an ICS file.
   - `status` (map)
-
-    - `type` (string): The status type of the synchronization (`inProgress`, `failed`, `success`)
-    - `message` (string): The error message if the synchronization failed
-    - `syncTrigger` (string): The trigger of the synchronization (`on_create`, `manual`, `scheduled`)
-    - `lastSuccessfulSync` (timestamp): The timestamp of the last successful synchronization
-
+    - `type` (string): The status type of the synchronization (`inProgress`, `failed`, `success`, `deleting`).
+    - `message` (string, optional): Error message if synchronization failed.
+    - `lastSuccessfulSync` (timestamp, optional): Timestamp of the last successful synchronization.
   - `targetCalendar` (map)
-    - `id` (string): The ID of the target calendar
-    - `title` (string): The title of the target calendar, given by the calendar provider.
-    - `description` (string): The description of the target calendar, given by the calendar provider.
-    - `providerAccountId` (string): This is the unique identifier for the account that owns the target calendar. It is not the same as the Firebase Auth ID used in our app. Currently, this ID represents a Google account, but in the future, it could also represent accounts from other providers like Microsoft. This distinction is important because a single user of our app can manage multiple synchronization profiles, each targeting calendars owned by different accounts across various providers.
-  - `ruleset` (string): A valid JSON string a Ruleset to apply.
+    - `id` (string): ID of the target calendar.
+    - `title` (string): Title of the target calendar, provided by the calendar provider.
+    - `description` (string): Description of the target calendar, provided by the calendar provider.
+    - `providerAccountId` (string): Unique identifier for the account owning the target calendar (e.g., Google account ID).
+  - `ruleset` (string, optional): JSON string of a `Ruleset` to apply.
+  - `ruleset_error` (string, optional): Error message if generating the ruleset failed.
+  - `created_at` (timestamp): Timestamp when the sync profile was created.
+
+- #### `syncStats`
+  A collection to track the number of synchronizations performed by a user on a given date. IDs are formatted as `YYYY-MM-DD`.
+
+  **Fields**
+
+  - `syncCount` (integer): Number of synchronizations performed on that date.
 
 ### `backendAuthorizations` collection
 
-Document ID: `userId` + `providerAccountId`
+IDs: concatenation of  `userId` + `providerAccountId`.
 
-**Fields:**
+**Fields**
 
-- `userId` (string): The ID of the user who authorized the backend
-- `provider` (string): The provider of the authorized account. For now, it is always `google`
-- `providerAccountId` (string): The unique identifier of the authorized Google account
-- `providerAccountEmail` (string): The email of the authorized Google account
-- `accessToken` (string): The access token obtained from the OAuth2 flow
-- `refreshToken` (string): The refresh token obtained from the OAuth2 flow
-- `expirationDate` (timestamp): The expiration date of the credentials
+- `userId` (string): ID of the user who authorized the backend.
+- `provider` (string): Provider of the authorized account (e.g., `google`).
+- `providerAccountId` (string): Unique identifier of the authorized provider account.
+- `providerAccountEmail` (string): Email of the authorized provider account.
+- `accessToken` (string): Access token obtained from the OAuth2 flow.
+- `refreshToken` (string): Refresh token obtained from the OAuth2 flow.
+- `expirationDate` (timestamp): Expiration date of the credentials.

--- a/functions/main.py
+++ b/functions/main.py
@@ -215,6 +215,8 @@ def create_new_calendar(req: https_fn.CallableRequest) -> dict:
             https_fn.FunctionsErrorCode.INVALID_ARGUMENT,
             "Invalid colorId. Must be an integer between 1 and 25.",
         )
+    
+    logger.info(f"Creating new calendar for {user_id}/{provider_account_id}")
 
     try:
         service = get_calendar_service(user_id, provider_account_id)

--- a/syncademic_app/lib/main.dart
+++ b/syncademic_app/lib/main.dart
@@ -116,9 +116,9 @@ void main() async {
 
   if (kDebugMode) {
     try {
-      FirebaseFirestore.instance.useFirestoreEmulator('localhost', 8080);
-      await FirebaseAuth.instance.useAuthEmulator('localhost', 9099);
-      FirebaseFunctions.instance.useFunctionsEmulator('localhost', 5001);
+      // FirebaseFirestore.instance.useFirestoreEmulator('localhost', 8080);
+      // await FirebaseAuth.instance.useAuthEmulator('localhost', 9099);
+      // FirebaseFunctions.instance.useFunctionsEmulator('localhost', 5001);
     } catch (e) {
       log("Error connecting to the local Firebase emulator: $e");
     }

--- a/syncademic_app/lib/main.dart
+++ b/syncademic_app/lib/main.dart
@@ -116,9 +116,9 @@ void main() async {
 
   if (kDebugMode) {
     try {
-      // FirebaseFirestore.instance.useFirestoreEmulator('localhost', 8080);
-      // await FirebaseAuth.instance.useAuthEmulator('localhost', 9099);
-      // FirebaseFunctions.instance.useFunctionsEmulator('localhost', 5001);
+      FirebaseFirestore.instance.useFirestoreEmulator('localhost', 8080);
+      await FirebaseAuth.instance.useAuthEmulator('localhost', 9099);
+      FirebaseFunctions.instance.useFunctionsEmulator('localhost', 5001);
     } catch (e) {
       log("Error connecting to the local Firebase emulator: $e");
     }

--- a/syncademic_app/lib/models/target_calendar.dart
+++ b/syncademic_app/lib/models/target_calendar.dart
@@ -33,6 +33,7 @@ class TargetCalendar with _$TargetCalendar {
     /// of the calendar itself. It is also different from the user ID that is logged in to the Syncademic app,
     /// as a user can have multiple accounts on multiple calendar services.
     required String providerAccountId,
+    required String providerAccountEmail,
     bool? createdBySyncademic,
   }) = _TargetCalendar;
 }

--- a/syncademic_app/lib/repositories/firestore_sync_profile_repository.dart
+++ b/syncademic_app/lib/repositories/firestore_sync_profile_repository.dart
@@ -69,6 +69,7 @@ class FirestoreSyncProfileRepository implements SyncProfileRepository {
       title: data['targetCalendar']['title'],
       providerAccountId: data['targetCalendar']['providerAccountId'],
       description: data['targetCalendar']['description'],
+      providerAccountEmail: data['targetCalendar']['providerAccountEmail'],
     );
 
     late SyncProfileStatus

--- a/syncademic_app/lib/repositories/firestore_sync_profile_repository.dart
+++ b/syncademic_app/lib/repositories/firestore_sync_profile_repository.dart
@@ -27,6 +27,7 @@ class FirestoreSyncProfileRepository implements SyncProfileRepository {
         'title': syncProfile.targetCalendar.title,
         'description': syncProfile.targetCalendar.description,
         'providerAccountId': syncProfile.targetCalendar.providerAccountId,
+        'providerAccountEmail': syncProfile.targetCalendar.providerAccountEmail,
       },
       'status': {'type': 'notStarted'}
     });

--- a/syncademic_app/lib/repositories/google_target_calendar_repository.dart
+++ b/syncademic_app/lib/repositories/google_target_calendar_repository.dart
@@ -8,7 +8,7 @@ class GoogleTargetCalendarRepository implements TargetCalendarRepository {
 
   @override
   Future<List<TargetCalendar>> getCalendars(
-    String providerAccountId,
+    {required String providerAccountId, required String providerAccountEmail}
   ) async {
     final result = await FirebaseFunctions.instance
         .httpsCallable('list_user_calendars')
@@ -22,6 +22,7 @@ class GoogleTargetCalendarRepository implements TargetCalendarRepository {
               title: calendar['summary'] ?? 'Unnamed calendar',
               description: calendar['description'],
               providerAccountId: providerAccountId,
+              providerAccountEmail: providerAccountEmail,
             ))
         .toList();
   }
@@ -34,6 +35,7 @@ class GoogleTargetCalendarRepository implements TargetCalendarRepository {
         .httpsCallable('create_new_calendar')
         .call({
       'providerAccountId': providerAccountId,
+      'providerAccountEmail': targetCalendar.providerAccountEmail,
       'summary': targetCalendar.title,
       'description': targetCalendar.description,
       'colorId': color == null ? null : int.parse(color.id),

--- a/syncademic_app/lib/repositories/google_target_calendar_repository.dart
+++ b/syncademic_app/lib/repositories/google_target_calendar_repository.dart
@@ -1,5 +1,6 @@
 import 'package:cloud_functions/cloud_functions.dart';
 import '../models/id.dart';
+import '../models/provider_account.dart';
 import '../models/target_calendar.dart';
 import 'target_calendar_repository.dart';
 
@@ -8,11 +9,10 @@ class GoogleTargetCalendarRepository implements TargetCalendarRepository {
 
   @override
   Future<List<TargetCalendar>> getCalendars(
-    {required String providerAccountId, required String providerAccountEmail}
-  ) async {
+      ProviderAccount providerAccount) async {
     final result = await FirebaseFunctions.instance
         .httpsCallable('list_user_calendars')
-        .call({'providerAccountId': providerAccountId});
+        .call({'providerAccountId': providerAccount.providerAccountId});
 
     final calendars = result.data['calendars'] as List<dynamic>;
 
@@ -21,8 +21,8 @@ class GoogleTargetCalendarRepository implements TargetCalendarRepository {
               id: ID.fromString(calendar['id']),
               title: calendar['summary'] ?? 'Unnamed calendar',
               description: calendar['description'],
-              providerAccountId: providerAccountId,
-              providerAccountEmail: providerAccountEmail,
+              providerAccountId: providerAccount.providerAccountId,
+              providerAccountEmail: providerAccount.providerAccountEmail,
             ))
         .toList();
   }

--- a/syncademic_app/lib/repositories/sync_profile_repository.dart
+++ b/syncademic_app/lib/repositories/sync_profile_repository.dart
@@ -68,6 +68,7 @@ class MockSyncProfileRepository implements SyncProfileRepository {
       title: 'Calendar ${id.value}',
       description: 'Description of calendar ${id.value}',
       providerAccountId: 'providerAccountId',
+      providerAccountEmail: 'test@syncademic.io',
     );
 
     int seconds = Random().nextInt(60);

--- a/syncademic_app/lib/repositories/target_calendar_repository.dart
+++ b/syncademic_app/lib/repositories/target_calendar_repository.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:syncademic_app/models/provider_account.dart';
 
 import '../models/id.dart';
 import '../models/target_calendar.dart';
@@ -51,7 +52,7 @@ enum GoogleCalendarColor {
 }
 
 abstract class TargetCalendarRepository {
-  Future<List<TargetCalendar>> getCalendars({required String providerAccountId, required String providerAccountEmail});
+  Future<List<TargetCalendar>> getCalendars(ProviderAccount providerAccount);
 
   Future<TargetCalendar> createCalendar(
       String providerAccountId, TargetCalendar calendar,
@@ -72,7 +73,7 @@ class MockTargetCalendarRepository implements TargetCalendarRepository {
 
   @override
   Future<List<TargetCalendar>> getCalendars(
-          {required String providerAccountId, required String providerAccountEmail}
+          ProviderAccount providerAccount
   ) async =>
       _calendars;
 

--- a/syncademic_app/lib/repositories/target_calendar_repository.dart
+++ b/syncademic_app/lib/repositories/target_calendar_repository.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:syncademic_app/models/provider_account.dart';
+import '../models/provider_account.dart';
 
 import '../models/id.dart';
 import '../models/target_calendar.dart';

--- a/syncademic_app/lib/repositories/target_calendar_repository.dart
+++ b/syncademic_app/lib/repositories/target_calendar_repository.dart
@@ -51,7 +51,7 @@ enum GoogleCalendarColor {
 }
 
 abstract class TargetCalendarRepository {
-  Future<List<TargetCalendar>> getCalendars(String providerAccountId);
+  Future<List<TargetCalendar>> getCalendars({required String providerAccountId, required String providerAccountEmail});
 
   Future<TargetCalendar> createCalendar(
       String providerAccountId, TargetCalendar calendar,
@@ -66,12 +66,13 @@ class MockTargetCalendarRepository implements TargetCalendarRepository {
       title: 'Calendar $index',
       description: 'Description of calendar $index',
       providerAccountId: 'providerAccountId',
+      providerAccountEmail: 'providerAccountEmail',
     ),
   );
 
   @override
   Future<List<TargetCalendar>> getCalendars(
-    String providerAccountId,
+          {required String providerAccountId, required String providerAccountEmail}
   ) async =>
       _calendars;
 

--- a/syncademic_app/lib/screens/new_sync_profile/cubit/new_sync_profile_cubit.dart
+++ b/syncademic_app/lib/screens/new_sync_profile/cubit/new_sync_profile_cubit.dart
@@ -104,19 +104,19 @@ class NewSyncProfileCubit extends Cubit<NewSyncProfileState> {
     ));
   }
 
-  Future<void> providerAccountSelected(ProviderAccount? providerAccount) async {
-    if (providerAccount == null) {
-      return emit(state.copyWith(
-        providerAccount: null,
-        providerAccountError: 'No provider account selected.',
-      ));
-    }
-
-    emit(state.copyWith(
-      providerAccount: providerAccount,
-      providerAccountError: null,
-    ));
-  }
+  Future<void> providerAccountSelected(
+          ProviderAccount? providerAccount) async =>
+      emit(
+        providerAccount == null
+            ? state.copyWith(
+                providerAccount: null,
+                providerAccountError: 'No provider account selected.',
+              )
+            : state.copyWith(
+                providerAccount: providerAccount,
+                providerAccountError: null,
+              ),
+      );
 
   Future<void> pickProviderAccount() async {
     await resetProviderAccount();
@@ -261,7 +261,7 @@ class NewSyncProfileCubit extends Cubit<NewSyncProfileState> {
         targetCalendar =
             await GetIt.I<TargetCalendarRepository>().createCalendar(
           state.providerAccount!.providerAccountId,
-          state.newCalendarCreated!,
+          state.newCalendarToBeCreated!,
           color: state.targetCalendarColor,
         ); //TODO : move the creation responsability to the backend
       } catch (e) {

--- a/syncademic_app/lib/screens/new_sync_profile/cubit/new_sync_profile_cubit.dart
+++ b/syncademic_app/lib/screens/new_sync_profile/cubit/new_sync_profile_cubit.dart
@@ -49,13 +49,6 @@ class NewSyncProfileCubit extends Cubit<NewSyncProfileState> {
     emit(state.copyWith(
       title: title,
       titleError: null,
-      newCalendarCreated: TargetCalendar(
-        id: ID(), // Will be overwritten by the calendar API
-        title: title,
-        providerAccountId: '',
-        createdBySyncademic: true,
-        description: "Calendar created by Syncademic.io",
-      ),
     ));
   }
 

--- a/syncademic_app/lib/screens/new_sync_profile/cubit/new_sync_profile_state.dart
+++ b/syncademic_app/lib/screens/new_sync_profile/cubit/new_sync_profile_state.dart
@@ -39,7 +39,6 @@ class NewSyncProfileState with _$NewSyncProfileState {
     ProviderAccount? providerAccount,
     @Default(null) String? providerAccountError,
     TargetCalendar? existingCalendarSelected,
-    TargetCalendar? newCalendarCreated,
     @Default(BackendAuthorizationStatus.notAuthorized)
     BackendAuthorizationStatus backendAuthorizationStatus,
     String? backendAuthorizationError,
@@ -66,6 +65,14 @@ class NewSyncProfileState with _$NewSyncProfileState {
 
   bool get canGoBack => currentStep.index > 0;
 
+  TargetCalendar? get newCalendarToBeCreated => TargetCalendar(
+        id: ID(),
+        title: title,
+        description: '',
+        providerAccountId: providerAccount!.providerAccountId,
+        providerAccountEmail: providerAccount!.providerAccountEmail,
+      );
+
   /// The target calendar that the user has selected.
   ///
   /// If the user has selected to create a new calendar, this will be the new calendar.
@@ -73,7 +80,7 @@ class NewSyncProfileState with _$NewSyncProfileState {
   TargetCalendar? get targetCalendarSelected {
     switch (targetCalendarChoice) {
       case TargetCalendarChoice.createNew:
-        return newCalendarCreated;
+        return newCalendarToBeCreated;
       case TargetCalendarChoice.useExisting:
         return existingCalendarSelected;
     }

--- a/syncademic_app/lib/screens/new_sync_profile/cubit/new_sync_profile_state.dart
+++ b/syncademic_app/lib/screens/new_sync_profile/cubit/new_sync_profile_state.dart
@@ -78,6 +78,10 @@ class NewSyncProfileState with _$NewSyncProfileState {
   /// If the user has selected to create a new calendar, this will be the new calendar.
   /// If the user has selected to use an existing calendar, this will be the existing calendar.
   TargetCalendar? get targetCalendarSelected {
+    if (providerAccount == null) {
+      return null;
+    }
+
     switch (targetCalendarChoice) {
       case TargetCalendarChoice.createNew:
         return newCalendarToBeCreated;

--- a/syncademic_app/lib/screens/new_sync_profile/target_calendar_selector/target_calendar_selector_cubit.dart
+++ b/syncademic_app/lib/screens/new_sync_profile/target_calendar_selector/target_calendar_selector_cubit.dart
@@ -24,7 +24,7 @@ class TargetCalendarSelectorCubit extends Cubit<TargetCalendarSelectorState> {
           .get<TargetCalendarRepository>()
           .getCalendars(providerAccount);
     } catch (e) {
-      emit(state.copyWith(loading: false, error: e.toString()));
+      return emit(state.copyWith(loading: false, error: e.toString()));
     }
 
     emit(state.copyWith(loading: false, calendars: calendars, error: null));

--- a/syncademic_app/lib/screens/new_sync_profile/target_calendar_selector/target_calendar_selector_cubit.dart
+++ b/syncademic_app/lib/screens/new_sync_profile/target_calendar_selector/target_calendar_selector_cubit.dart
@@ -22,7 +22,7 @@ class TargetCalendarSelectorCubit extends Cubit<TargetCalendarSelectorState> {
     try {
       calendars = await GetIt.I
           .get<TargetCalendarRepository>()
-          .getCalendars(providerAccount.providerAccountId);
+          .getCalendars(providerAccount);
     } catch (e) {
       emit(state.copyWith(loading: false, error: e.toString()));
     }

--- a/syncademic_app/lib/widgets/target_calendar_card.dart
+++ b/syncademic_app/lib/widgets/target_calendar_card.dart
@@ -46,12 +46,10 @@ class TargetCalendarCard extends StatelessWidget {
                             targetCalendar.title,
                             style: Theme.of(context).textTheme.titleLarge,
                           ),
-                          if (targetCalendar.description != null) ...[
-                            Text(
-                              targetCalendar.description!,
-                              style: Theme.of(context).textTheme.bodySmall,
-                            )
-                          ]
+                          Text(
+                            targetCalendar.providerAccountEmail,
+                            style: Theme.of(context).textTheme.bodySmall,
+                          )
                         ],
                       ),
                     ),

--- a/syncademic_app/pubspec.yaml
+++ b/syncademic_app/pubspec.yaml
@@ -17,7 +17,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.1.30
+version: 0.1.31
 
 environment:
   sdk: ">=3.2.6 <4.0.0"

--- a/syncademic_app/test/models/sync_profile_test.dart
+++ b/syncademic_app/test/models/sync_profile_test.dart
@@ -17,6 +17,7 @@ void main() {
     id: ID(),
     title: 'targetCalendarTitle',
     providerAccountId: 'providerAccountId',
+    providerAccountEmail: 'test@syncademic.io',
   );
 
   const status = SyncProfileStatus.notStarted();

--- a/syncademic_app/test/models/target_calendar_test.dart
+++ b/syncademic_app/test/models/target_calendar_test.dart
@@ -6,16 +6,19 @@ void main() {
   const id = ID.fromString('test_id');
   const title = 'Test Title';
   const providerAccountId = 'providerAccountId';
+  const email = 'test@syncademic.io';
 
   TargetCalendar createTargetCalendar({
     ID id = id,
     String title = title,
     String providerAccountId = providerAccountId,
+    String providerAccountEmail = email,
   }) =>
       TargetCalendar(
         id: id,
         title: title,
         providerAccountId: providerAccountId,
+        providerAccountEmail: providerAccountEmail,
       );
 
   test('should create a TargetCalendar instance', () {
@@ -23,11 +26,13 @@ void main() {
       id: id,
       title: title,
       providerAccountId: providerAccountId,
+      providerAccountEmail: email,
     );
 
     expect(targetCalendar.id, id);
     expect(targetCalendar.title, title);
     expect(targetCalendar.providerAccountId, providerAccountId);
+    expect(targetCalendar.providerAccountEmail, email);
   });
 
   group('equals', () {
@@ -63,6 +68,16 @@ void main() {
 
       expect(targetCalendar1, isNot(equals(targetCalendar2)));
     });
+
+    test(
+        'should not be equal to another TargetCalendar with a different providerAccountEmail',
+        () {
+      final targetCalendar1 = createTargetCalendar(providerAccountEmail: 'testA@syncademic.io');
+      final targetCalendar2 = createTargetCalendar(providerAccountEmail: 'testB@syncademic.io'); 
+
+      expect(targetCalendar1, isNot(equals(targetCalendar2)));
+    });
+
 
     test(
         'should have the same hash code for TargetCalendars with the same values',

--- a/syncademic_app/test/screens/sync_profile/cubit/sync_profile_state_test.dart
+++ b/syncademic_app/test/screens/sync_profile/cubit/sync_profile_state_test.dart
@@ -13,6 +13,7 @@ final targetCalendar1 = TargetCalendar(
   description: "Description 1",
   providerAccountId: "6371892",
   createdBySyncademic: true,
+  providerAccountEmail: 'test@syncademic.io'
 );
 
 SyncProfile getSyncProfile({


### PR DESCRIPTION
When creating a new synchronization, we now to **store the email of the account associated with the selected/created google calendar**. This email is **now prominently displayed in the UI**. 