### PR TITLE
Fix last synced property

### DIFF
--- a/dev/docs/firestore.md
+++ b/dev/docs/firestore.md
@@ -20,7 +20,6 @@
   - `status` (map)
     - `type` (string): The status type of the synchronization (`inProgress`, `failed`, `success`, `deleting`).
     - `message` (string, optional): Error message if synchronization failed.
-    - `lastSuccessfulSync` (timestamp, optional): Timestamp of the last successful synchronization.
   - `targetCalendar` (map)
     - `id` (string): ID of the target calendar.
     - `title` (string): Title of the target calendar, provided by the calendar provider.
@@ -30,6 +29,7 @@
   - `ruleset` (string, optional): JSON string of a `Ruleset` to apply.
   - `ruleset_error` (string, optional): Error message if generating the ruleset failed.
   - `created_at` (timestamp): Timestamp when the sync profile was created.
+  - `lastSuccessfulSync` (timestamp, optional): Timestamp of the last successful synchronization.
 
 - #### `syncStats`
   A collection to track the number of synchronizations performed by a user on a given date. IDs are formatted as `YYYY-MM-DD`.

--- a/dev/docs/firestore.md
+++ b/dev/docs/firestore.md
@@ -20,6 +20,9 @@
   - `status` (map)
     - `type` (string): The status type of the synchronization (`inProgress`, `failed`, `success`, `deleting`).
     - `message` (string, optional): Error message if synchronization failed.
+    - `syncTrigger` (string): The trigger that initiated the synchronization (`on_create`, `manuel`, `scheduled`).
+    - `syncType` (string) : Whether to sync only updated events or everything (`regular`, `full`).
+    - `updatedAt` (timestamp): Timestamp of the last status update.
   - `targetCalendar` (map)
     - `id` (string): ID of the target calendar.
     - `title` (string): Title of the target calendar, provided by the calendar provider.

--- a/functions/main.py
+++ b/functions/main.py
@@ -192,8 +192,7 @@ def is_authorized(req: https_fn.CallableRequest) -> dict:
         logger.info("Backend authorization not found")
         return {"authorized": False}
 
-
-    #TODO : create service and use GoogleCalendarManager to test authorization here
+    # TODO : create service and use GoogleCalendarManager to test authorization here
 
     logger.info("Authorization successful")
     return {"authorized": True}
@@ -454,6 +453,7 @@ def _synchronize_now(
                 "type": "inProgress",
                 "syncTrigger": sync_trigger,
                 "syncType": sync_type,
+                "updatedAt": firestore.firestore.SERVER_TIMESTAMP,
             }
         }
     )
@@ -487,6 +487,7 @@ def _synchronize_now(
                     "message": f"Daily synchronization limit of {settings.MAX_SYNCHRONIZATIONS_PER_DAY} reached.",
                     "syncTrigger": sync_trigger,
                     "syncType": sync_type,
+                    "updatedAt": firestore.firestore.SERVER_TIMESTAMP,
                 }
             }
         )
@@ -510,6 +511,7 @@ def _synchronize_now(
                     # TODO : implement a way to re-authorize from the frontend
                     "syncTrigger": sync_trigger,
                     "syncType": sync_type,
+                    "updatedAt": firestore.firestore.SERVER_TIMESTAMP,
                 }
             }
         )
@@ -530,6 +532,7 @@ def _synchronize_now(
                         "message": f"Failed to validate ruleset: {e}",
                         "syncTrigger": sync_trigger,
                         "syncType": sync_type,
+                        "updatedAt": firestore.firestore.SERVER_TIMESTAMP,
                     }
                 }
             )
@@ -555,6 +558,7 @@ def _synchronize_now(
                     "message": f"Synchronization failed: {e}",
                     "syncTrigger": sync_trigger,
                     "syncType": sync_type,
+                    "updatedAt": firestore.firestore.SERVER_TIMESTAMP,
                 }
             }
         )
@@ -567,8 +571,9 @@ def _synchronize_now(
                 "type": "success",
                 "syncTrigger": sync_trigger,
                 "syncType": sync_type,
-                "lastSuccessfulSync": firestore.firestore.SERVER_TIMESTAMP,
+                "updatedAt": firestore.firestore.SERVER_TIMESTAMP,
             },
+            "lastSuccessfulSync": firestore.firestore.SERVER_TIMESTAMP,
         }
     )
     sync_stats_ref.set({"syncCount": firestore.firestore.Increment(1)}, merge=True)

--- a/syncademic_app/lib/models/sync_profile.dart
+++ b/syncademic_app/lib/models/sync_profile.dart
@@ -15,5 +15,6 @@ class SyncProfile with _$SyncProfile {
     required TargetCalendar targetCalendar,
     required String title,
     required SyncProfileStatus status,
+    DateTime? lastSuccessfulSync,
   }) = _SyncProfile;
 }

--- a/syncademic_app/lib/models/sync_profile_status.dart
+++ b/syncademic_app/lib/models/sync_profile_status.dart
@@ -6,12 +6,30 @@ part 'sync_profile_status.freezed.dart';
 class SyncProfileStatus with _$SyncProfileStatus {
   const SyncProfileStatus._();
 
-  const factory SyncProfileStatus.success( {String? syncTrigger}) = _Success;
-  const factory SyncProfileStatus.inProgress( {String? syncTrigger}) = _InProgress;
-  const factory SyncProfileStatus.failed(String message, {String? syncTrigger}) = _Failed;
-  const factory SyncProfileStatus.notStarted( {String? syncTrigger}) = _NotStarted;
-  const factory SyncProfileStatus.deleting() = _Deleting;
-  const factory SyncProfileStatus.deletionFailed( String message ) = _DeletionFailed;
+  const factory SyncProfileStatus.success({
+    String? syncTrigger,
+    required DateTime updatedAt,
+  }) = _Success;
+  const factory SyncProfileStatus.inProgress({
+    String? syncTrigger,
+    required DateTime updatedAt,
+  }) = _InProgress;
+  const factory SyncProfileStatus.failed(
+    String message, {
+    String? syncTrigger,
+    required DateTime updatedAt,
+  }) = _Failed;
+  const factory SyncProfileStatus.notStarted({
+    String? syncTrigger,
+    required DateTime updatedAt,
+  }) = _NotStarted;
+  const factory SyncProfileStatus.deleting({
+    required DateTime updatedAt,
+  }) = _Deleting;
+  const factory SyncProfileStatus.deletionFailed(
+    String message, {
+    required DateTime updatedAt,
+  }) = _DeletionFailed;
 
   bool isInProgress() => maybeMap(
         orElse: () => false,

--- a/syncademic_app/lib/models/sync_profile_status.dart
+++ b/syncademic_app/lib/models/sync_profile_status.dart
@@ -6,21 +6,12 @@ part 'sync_profile_status.freezed.dart';
 class SyncProfileStatus with _$SyncProfileStatus {
   const SyncProfileStatus._();
 
-  const factory SyncProfileStatus.success(
-      {String? syncTrigger, DateTime? lastSuccessfulSync}) = _Success;
-  const factory SyncProfileStatus.inProgress(
-      {String? syncTrigger, DateTime? lastSuccessfulSync}) = _InProgress;
-  const factory SyncProfileStatus.failed(String message,
-      {String? syncTrigger, DateTime? lastSuccessfulSync}) = _Failed;
-  const factory SyncProfileStatus.notStarted(
-      {String? syncTrigger, DateTime? lastSuccessfulSync}) = _NotStarted;
-  const factory SyncProfileStatus.deleting({
-    DateTime? lastSuccessfulSync,
-  }) = _Deleting;
-  const factory SyncProfileStatus.deletionFailed(
-    String message, {
-    DateTime? lastSuccessfulSync,
-  }) = _DeletionFailed;
+  const factory SyncProfileStatus.success( {String? syncTrigger}) = _Success;
+  const factory SyncProfileStatus.inProgress( {String? syncTrigger}) = _InProgress;
+  const factory SyncProfileStatus.failed(String message, {String? syncTrigger}) = _Failed;
+  const factory SyncProfileStatus.notStarted( {String? syncTrigger}) = _NotStarted;
+  const factory SyncProfileStatus.deleting() = _Deleting;
+  const factory SyncProfileStatus.deletionFailed( String message ) = _DeletionFailed;
 
   bool isInProgress() => maybeMap(
         orElse: () => false,

--- a/syncademic_app/lib/repositories/firestore_sync_profile_repository.dart
+++ b/syncademic_app/lib/repositories/firestore_sync_profile_repository.dart
@@ -79,30 +79,22 @@ class FirestoreSyncProfileRepository implements SyncProfileRepository {
       case 'inProgress':
         status = SyncProfileStatus.inProgress(
           syncTrigger: data['status']['syncTrigger'],
-          lastSuccessfulSync:
-              (data['status']['lastSuccessfulSync'] as Timestamp?)?.toDate(),
         );
         break;
       case 'success':
         status = SyncProfileStatus.success(
           syncTrigger: data['status']['syncTrigger'],
-          lastSuccessfulSync:
-              (data['status']['lastSuccessfulSync'] as Timestamp?)?.toDate(),
         );
         break;
       case 'failed':
         status = SyncProfileStatus.failed(
           data['status']['message'] ?? '',
           syncTrigger: data['status']['syncTrigger'],
-          lastSuccessfulSync:
-              (data['status']['lastSuccessfulSync'] as Timestamp?)?.toDate(),
         );
         break;
       case 'notStarted':
         status = SyncProfileStatus.notStarted(
           syncTrigger: data['status']['syncTrigger'],
-          lastSuccessfulSync:
-              (data['status']['lastSuccessfulSync'] as Timestamp?)?.toDate(),
         );
         break;
       case 'deleting':
@@ -116,19 +108,16 @@ class FirestoreSyncProfileRepository implements SyncProfileRepository {
         log('Could not parse status: ${data['status']}');
     }
 
-    return SyncProfile(
-      id: ID.fromString(id),
-      title: data['title'],
-      scheduleSource: scheduleSource,
-      targetCalendar: targetCalendar,
-      status: status,
-    );
-  }
+    final lastSuccessfulSync =
+        (data['lastSuccessfulSync'] as Timestamp?)?.toDate();
 
-  @override
-  Future<void> updateSyncProfile(SyncProfile syncProfile) {
-    // TODO: implement updateSyncProfile
-    throw UnimplementedError();
+    return SyncProfile(
+        id: ID.fromString(id),
+        title: data['title'],
+        scheduleSource: scheduleSource,
+        targetCalendar: targetCalendar,
+        status: status,
+        lastSuccessfulSync: lastSuccessfulSync);
   }
 
   CollectionReference get _syncProfilesCollection {

--- a/syncademic_app/lib/repositories/firestore_sync_profile_repository.dart
+++ b/syncademic_app/lib/repositories/firestore_sync_profile_repository.dart
@@ -16,22 +16,25 @@ class FirestoreSyncProfileRepository implements SyncProfileRepository {
   final _db = FirebaseFirestore.instance;
 
   @override
-  Future<void> createSyncProfile(SyncProfile syncProfile) async {
-    _syncProfilesCollection.doc(syncProfile.id.value).set({
-      'title': syncProfile.title,
-      'scheduleSource': {
-        'url': syncProfile.scheduleSource.url,
-      },
-      'targetCalendar': {
-        'id': syncProfile.targetCalendar.id.value,
-        'title': syncProfile.targetCalendar.title,
-        'description': syncProfile.targetCalendar.description,
-        'providerAccountId': syncProfile.targetCalendar.providerAccountId,
-        'providerAccountEmail': syncProfile.targetCalendar.providerAccountEmail,
-      },
-      'status': {'type': 'notStarted'}
-    });
-  }
+  Future<void> createSyncProfile(SyncProfile syncProfile) async =>
+      _syncProfilesCollection.doc(syncProfile.id.value).set({
+        'title': syncProfile.title,
+        'scheduleSource': {
+          'url': syncProfile.scheduleSource.url,
+        },
+        'targetCalendar': {
+          'id': syncProfile.targetCalendar.id.value,
+          'title': syncProfile.targetCalendar.title,
+          'description': syncProfile.targetCalendar.description,
+          'providerAccountId': syncProfile.targetCalendar.providerAccountId,
+          'providerAccountEmail':
+              syncProfile.targetCalendar.providerAccountEmail,
+        },
+        'status': {
+          'type': 'notStarted',
+          'updatedAt': FieldValue.serverTimestamp(),
+        },
+      });
 
   @override
   Stream<SyncProfile?> watchSyncProfile(ID id) {
@@ -54,7 +57,6 @@ class FirestoreSyncProfileRepository implements SyncProfileRepository {
     await for (final snapshot in _syncProfilesCollection.snapshots()) {
       yield snapshot.docs.map((doc) {
         final data = doc.data() as Map<String, dynamic>;
-        // TODO : Handle parsing error
         return _fromData(data, doc.id);
       }).toList();
     }
@@ -75,34 +77,43 @@ class FirestoreSyncProfileRepository implements SyncProfileRepository {
 
     late SyncProfileStatus
         status; //TODO : Refactor this crap (https://pub.dev/packages/deep_pick)
+    final updatedAt = (data['updatedAt'] as Timestamp).toDate();
     switch (data['status']['type']) {
       case 'inProgress':
         status = SyncProfileStatus.inProgress(
           syncTrigger: data['status']['syncTrigger'],
+          updatedAt: updatedAt,
         );
         break;
       case 'success':
         status = SyncProfileStatus.success(
           syncTrigger: data['status']['syncTrigger'],
+          updatedAt: updatedAt,
         );
         break;
       case 'failed':
         status = SyncProfileStatus.failed(
           data['status']['message'] ?? '',
           syncTrigger: data['status']['syncTrigger'],
+          updatedAt: updatedAt,
         );
         break;
       case 'notStarted':
         status = SyncProfileStatus.notStarted(
           syncTrigger: data['status']['syncTrigger'],
+          updatedAt: updatedAt,
         );
         break;
       case 'deleting':
-        status = const SyncProfileStatus.deleting();
+        status = SyncProfileStatus.deleting(
+          updatedAt: updatedAt,
+        );
         break;
       case 'deletionFailed':
-        status =
-            SyncProfileStatus.deletionFailed(data['status']['message'] ?? '');
+        status = SyncProfileStatus.deletionFailed(
+          data['status']['message'] ?? '',
+          updatedAt: updatedAt,
+        );
         break;
       default:
         log('Could not parse status: ${data['status']}');
@@ -112,12 +123,13 @@ class FirestoreSyncProfileRepository implements SyncProfileRepository {
         (data['lastSuccessfulSync'] as Timestamp?)?.toDate();
 
     return SyncProfile(
-        id: ID.fromString(id),
-        title: data['title'],
-        scheduleSource: scheduleSource,
-        targetCalendar: targetCalendar,
-        status: status,
-        lastSuccessfulSync: lastSuccessfulSync);
+      id: ID.fromString(id),
+      title: data['title'],
+      scheduleSource: scheduleSource,
+      targetCalendar: targetCalendar,
+      status: status,
+      lastSuccessfulSync: lastSuccessfulSync,
+    );
   }
 
   CollectionReference get _syncProfilesCollection {

--- a/syncademic_app/lib/repositories/firestore_sync_profile_repository.dart
+++ b/syncademic_app/lib/repositories/firestore_sync_profile_repository.dart
@@ -77,7 +77,7 @@ class FirestoreSyncProfileRepository implements SyncProfileRepository {
 
     late SyncProfileStatus
         status; //TODO : Refactor this crap (https://pub.dev/packages/deep_pick)
-    final updatedAt = (data['updatedAt'] as Timestamp).toDate();
+    final updatedAt = (data['status']['updatedAt'] as Timestamp).toDate();
     switch (data['status']['type']) {
       case 'inProgress':
         status = SyncProfileStatus.inProgress(

--- a/syncademic_app/lib/repositories/sync_profile_repository.dart
+++ b/syncademic_app/lib/repositories/sync_profile_repository.dart
@@ -78,7 +78,9 @@ class MockSyncProfileRepository implements SyncProfileRepository {
       targetCalendar: targetCalendar,
       lastSuccessfulSync:
           DateTime.now().subtract(Duration(seconds: totalSeconds)),
-      status: const SyncProfileStatus.success(),
+      status: SyncProfileStatus.success(
+        updatedAt: DateTime.now().subtract(Duration(seconds: totalSeconds)),
+      ),
     );
   }
 
@@ -92,8 +94,10 @@ class MockSyncProfileRepository implements SyncProfileRepository {
   void addInProgressProfile() {
     var syncProfile = createRandomProfile();
     syncProfile = syncProfile.copyWith(
-      // lastSuccessfulSync: DateTime.now().subtract(const Duration(days: 1)),
-      status: const SyncProfileStatus.inProgress(),
+      lastSuccessfulSync: DateTime.now().subtract(const Duration(days: 1)),
+      status: SyncProfileStatus.inProgress(
+        updatedAt: DateTime.now().subtract(const Duration(seconds: 10)),
+      ),
     );
     _syncProfiles[syncProfile.id] = syncProfile;
   }
@@ -101,8 +105,10 @@ class MockSyncProfileRepository implements SyncProfileRepository {
   void addFailedProfile() {
     var syncProfile = createRandomProfile();
     syncProfile = syncProfile.copyWith(
-        // lastSuccessfulSync: DateTime.now().subtract(const Duration(days: 1)),
-        status: const SyncProfileStatus.failed("Error message"));
+        lastSuccessfulSync: DateTime.now().subtract(const Duration(days: 1)),
+        status: SyncProfileStatus.failed("Error message",
+            updatedAt: DateTime.now()
+                .subtract(const Duration(hours: 10, minutes: 30))));
 
     _syncProfiles[syncProfile.id] = syncProfile;
   }
@@ -110,8 +116,10 @@ class MockSyncProfileRepository implements SyncProfileRepository {
   void addNotStartedProfile() {
     var syncProfile = createRandomProfile();
     syncProfile = syncProfile.copyWith(
-      // lastSuccessfulSync: null,
-      status: const SyncProfileStatus.notStarted(),
+      lastSuccessfulSync: null,
+      status: SyncProfileStatus.notStarted(
+        updatedAt: DateTime.now().subtract(const Duration(seconds: 10)),
+      ),
     );
 
     _syncProfiles[syncProfile.id] = syncProfile;
@@ -120,7 +128,8 @@ class MockSyncProfileRepository implements SyncProfileRepository {
   void addDeletionFailedProfile() {
     var syncProfile = createRandomProfile();
     syncProfile = syncProfile.copyWith(
-        status: const SyncProfileStatus.deletionFailed("Deletion failed"));
+        status: SyncProfileStatus.deletionFailed("Deletion failed",
+            updatedAt: DateTime.now().subtract(const Duration(seconds: 10))));
 
     _syncProfiles[syncProfile.id] = syncProfile;
   }
@@ -132,8 +141,10 @@ class MockSyncProfileRepository implements SyncProfileRepository {
 
   @override
   Future<void> deleteSyncProfile(ID id) async {
-    _syncProfiles[id] =
-        _syncProfiles[id]!.copyWith(status: const SyncProfileStatus.deleting());
+    _syncProfiles[id] = _syncProfiles[id]!.copyWith(
+        status: SyncProfileStatus.deleting(
+      updatedAt: DateTime.now(),
+    ));
     _syncProfilesController.add(_syncProfiles.values.toList());
     await Future.delayed(const Duration(seconds: 2));
 

--- a/syncademic_app/lib/repositories/sync_profile_repository.dart
+++ b/syncademic_app/lib/repositories/sync_profile_repository.dart
@@ -12,7 +12,6 @@ abstract class SyncProfileRepository {
   Stream<List<SyncProfile>> getSyncProfiles();
 
   Future<void> createSyncProfile(SyncProfile syncProfile);
-  Future<void> updateSyncProfile(SyncProfile syncProfile);
   Stream<SyncProfile?> watchSyncProfile(ID id);
 
   Future<void> deleteSyncProfile(ID id);
@@ -42,13 +41,6 @@ class MockSyncProfileRepository implements SyncProfileRepository {
       throw Exception('SyncProfile already exists');
     }
 
-    _syncProfiles[syncProfile.id] = syncProfile;
-
-    _syncProfilesController.add(_syncProfiles.values.toList());
-  }
-
-  @override
-  Future<void> updateSyncProfile(SyncProfile syncProfile) async {
     _syncProfiles[syncProfile.id] = syncProfile;
 
     _syncProfilesController.add(_syncProfiles.values.toList());
@@ -84,10 +76,9 @@ class MockSyncProfileRepository implements SyncProfileRepository {
       title: 'Sync Profile n°${id.value}',
       scheduleSource: scheduleSource,
       targetCalendar: targetCalendar,
-      status: SyncProfileStatus.success(
-        lastSuccessfulSync:
-            DateTime.now().subtract(Duration(seconds: totalSeconds)),
-      ),
+      lastSuccessfulSync:
+          DateTime.now().subtract(Duration(seconds: totalSeconds)),
+      status: const SyncProfileStatus.success(),
     );
   }
 
@@ -101,9 +92,8 @@ class MockSyncProfileRepository implements SyncProfileRepository {
   void addInProgressProfile() {
     var syncProfile = createRandomProfile();
     syncProfile = syncProfile.copyWith(
-      status: SyncProfileStatus.inProgress(
-        lastSuccessfulSync: DateTime.now().subtract(const Duration(days: 1)),
-      ),
+      // lastSuccessfulSync: DateTime.now().subtract(const Duration(days: 1)),
+      status: const SyncProfileStatus.inProgress(),
     );
     _syncProfiles[syncProfile.id] = syncProfile;
   }
@@ -111,9 +101,8 @@ class MockSyncProfileRepository implements SyncProfileRepository {
   void addFailedProfile() {
     var syncProfile = createRandomProfile();
     syncProfile = syncProfile.copyWith(
-      status: SyncProfileStatus.failed("Error message",
-          lastSuccessfulSync: DateTime.now().subtract(const Duration(days: 1))),
-    );
+        // lastSuccessfulSync: DateTime.now().subtract(const Duration(days: 1)),
+        status: const SyncProfileStatus.failed("Error message"));
 
     _syncProfiles[syncProfile.id] = syncProfile;
   }
@@ -121,9 +110,8 @@ class MockSyncProfileRepository implements SyncProfileRepository {
   void addNotStartedProfile() {
     var syncProfile = createRandomProfile();
     syncProfile = syncProfile.copyWith(
-      status: const SyncProfileStatus.notStarted(
-        lastSuccessfulSync: null,
-      ),
+      // lastSuccessfulSync: null,
+      status: const SyncProfileStatus.notStarted(),
     );
 
     _syncProfiles[syncProfile.id] = syncProfile;

--- a/syncademic_app/lib/screens/new_sync_profile/cubit/new_sync_profile_cubit.dart
+++ b/syncademic_app/lib/screens/new_sync_profile/cubit/new_sync_profile_cubit.dart
@@ -281,7 +281,9 @@ class NewSyncProfileCubit extends Cubit<NewSyncProfileState> {
       title: state.title,
       scheduleSource: scheduleSource,
       targetCalendar: targetCalendar,
-      status: const SyncProfileStatus.notStarted(),
+      status: SyncProfileStatus.notStarted(
+        updatedAt: DateTime.now(),
+      ),
     );
 
     final repo = GetIt.I<SyncProfileRepository>();

--- a/syncademic_app/lib/widgets/last_synchronized.dart
+++ b/syncademic_app/lib/widgets/last_synchronized.dart
@@ -4,38 +4,35 @@ import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:get_time_ago/get_time_ago.dart';
 
-class LastSynchronized extends StatefulWidget {
-  const LastSynchronized(
+class TimeAgoBuilder extends StatefulWidget {
+  const TimeAgoBuilder(
       {super.key,
-      required this.lastSync,
+      required this.dt,
       this.builder,
       this.refreshRate = const Duration(seconds: 1)});
 
-  final DateTime? lastSync;
+  final DateTime dt;
   final Duration refreshRate;
 
   /// A builder that is called with the current last sync time.
-  final Function(BuildContext context, String? lastSync)? builder;
+  final Function(BuildContext context, String timeAgo)? builder;
 
   @override
-  State<LastSynchronized> createState() => _LastSynchronizedState();
+  State<TimeAgoBuilder> createState() => _TimeAgoBuilderState();
 }
 
-class _LastSynchronizedState extends State<LastSynchronized> {
+class _TimeAgoBuilderState extends State<TimeAgoBuilder> {
   late Timer _timer;
 
   @override
   void initState() {
     super.initState();
     _timer = Timer.periodic(widget.refreshRate, (timer) {
-      setState(() => updateLastSync(widget.lastSync));
+      setState(() => updateLastSync(widget.dt));
     });
   }
 
-  updateLastSync(DateTime? lastSync) {
-    if (lastSync == null) {
-      return _lastSync = 'unknown';
-    }
+  updateLastSync(DateTime lastSync) {
     _lastSync = GetTimeAgo.parse(lastSync);
   }
 

--- a/syncademic_app/lib/widgets/sync_profile_status_card.dart
+++ b/syncademic_app/lib/widgets/sync_profile_status_card.dart
@@ -14,7 +14,7 @@ class SyncProfileStatusCard extends StatelessWidget {
           title: Text(status.title),
           leading: status.leadingIcon,
           onTap: status.onTap != null ? () => status.onTap!(context) : null,
-          // subtitle: status.subtitle,
+          subtitle: status.subtitle,
         ),
       );
 }
@@ -38,14 +38,13 @@ extension on SyncProfileStatus {
         deletionFailed: (_) => const Icon(Icons.error, color: Colors.red),
       )!;
 
-  // Widget? get subtitle => maybeMap(
-  //       notStarted: (_) => null,
-  //       orElse: () => LastSynchronized(
-  //         lastSync: lastSuccessfulSync,
-  //         builder: (context, lastSync) =>
-  //             Text("Last sync: $lastSync"), // TODO : don't use colon
-  //       ),
-  //     );
+  Widget? get subtitle => maybeMap(
+        notStarted: (_) => null,
+        orElse: () => TimeAgoBuilder(
+          dt: updatedAt,
+          builder: (context, timeAgo) => Text(timeAgo),
+        ),
+      );
 
   void _showSnackBarError(BuildContext context, String message) =>
       ScaffoldMessenger.of(context)

--- a/syncademic_app/lib/widgets/sync_profile_status_card.dart
+++ b/syncademic_app/lib/widgets/sync_profile_status_card.dart
@@ -4,29 +4,19 @@ import '../models/sync_profile_status.dart';
 import 'last_synchronized.dart';
 
 class SyncProfileStatusCard extends StatelessWidget {
-  final SyncProfileStatus? status;
+  final SyncProfileStatus status;
 
   const SyncProfileStatusCard({super.key, required this.status});
 
   @override
-  Widget build(BuildContext context) {
-    if (status == null) {
-      return const Card(
-          child: ListTile(
-        title: Text('No status'),
-        leading: Icon(Icons.sync_problem),
-      ));
-    }
-
-    return Card(
-      child: ListTile(
-        title: Text(status!.title),
-        leading: status!.leadingIcon,
-        onTap: status!.onTap != null ? () => status!.onTap!(context) : null,
-        subtitle: status?.subtitle,
-      ),
-    );
-  }
+  Widget build(BuildContext context) => Card(
+        child: ListTile(
+          title: Text(status.title),
+          leading: status.leadingIcon,
+          onTap: status.onTap != null ? () => status.onTap!(context) : null,
+          // subtitle: status.subtitle,
+        ),
+      );
 }
 
 extension on SyncProfileStatus {
@@ -48,14 +38,14 @@ extension on SyncProfileStatus {
         deletionFailed: (_) => const Icon(Icons.error, color: Colors.red),
       )!;
 
-  Widget? get subtitle => maybeMap(
-        notStarted: (_) => null,
-        orElse: () => LastSynchronized(
-          lastSync: lastSuccessfulSync,
-          builder: (context, lastSync) =>
-              Text("Last sync: $lastSync"), // TODO : don't use colon
-        ),
-      );
+  // Widget? get subtitle => maybeMap(
+  //       notStarted: (_) => null,
+  //       orElse: () => LastSynchronized(
+  //         lastSync: lastSuccessfulSync,
+  //         builder: (context, lastSync) =>
+  //             Text("Last sync: $lastSync"), // TODO : don't use colon
+  //       ),
+  //     );
 
   void _showSnackBarError(BuildContext context, String message) =>
       ScaffoldMessenger.of(context)

--- a/syncademic_app/lib/widgets/sync_profiles_list.dart
+++ b/syncademic_app/lib/widgets/sync_profiles_list.dart
@@ -82,7 +82,7 @@ class _List extends StatelessWidget {
             itemCount: profiles.length,
             itemBuilder: (context, index) {
               final profile = profiles[index];
-              final lastSuccessfulSync = profile.status.lastSuccessfulSync;
+              final lastSuccessfulSync = profile.lastSuccessfulSync;
               return ListTile(
                   title: Text(profile.title,
                       style: Theme.of(context).textTheme.titleLarge),

--- a/syncademic_app/lib/widgets/sync_profiles_list.dart
+++ b/syncademic_app/lib/widgets/sync_profiles_list.dart
@@ -93,8 +93,8 @@ class _List extends StatelessWidget {
                   trailing: const Icon(Icons.chevron_right),
                   subtitle: lastSuccessfulSync == null
                       ? const Text('Never synced')
-                      : LastSynchronized(
-                          lastSync: lastSuccessfulSync,
+                      : TimeAgoBuilder(
+                          dt: lastSuccessfulSync,
                           builder: (_, lastSync) =>
                               Text('Last synced: $lastSync')),
                   onTap: onTap == null ? null : () => onTap!(profile));

--- a/syncademic_app/lib/widgets/sync_profiles_list.dart
+++ b/syncademic_app/lib/widgets/sync_profiles_list.dart
@@ -96,7 +96,7 @@ class _List extends StatelessWidget {
                       : TimeAgoBuilder(
                           dt: lastSuccessfulSync,
                           builder: (_, lastSync) =>
-                              Text('Last synced: $lastSync')),
+                              Text('Last synced $lastSync')),
                   onTap: onTap == null ? null : () => onTap!(profile));
             },
           );

--- a/syncademic_app/lib/widgets/sync_profiles_list.dart
+++ b/syncademic_app/lib/widgets/sync_profiles_list.dart
@@ -86,9 +86,10 @@ class _List extends StatelessWidget {
               return ListTile(
                   title: Text(profile.title,
                       style: Theme.of(context).textTheme.titleLarge),
-                  leading: const Icon(
-                    Icons.sync,
-                    color: Colors.grey,
+                  leading: profile.status.maybeMap(
+                    success: (_) => const Icon(Icons.sync, color: Colors.green),
+                    failed: (_) => const Icon(Icons.error, color: Colors.red),
+                    orElse: () => const Icon(Icons.sync, color: Colors.grey),
                   ),
                   trailing: const Icon(Icons.chevron_right),
                   subtitle: lastSuccessfulSync == null

--- a/syncademic_app/pubspec.yaml
+++ b/syncademic_app/pubspec.yaml
@@ -17,7 +17,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.1.31
+version: 0.1.32
 
 environment:
   sdk: ">=3.2.6 <4.0.0"

--- a/syncademic_app/test/models/sync_profile_test.dart
+++ b/syncademic_app/test/models/sync_profile_test.dart
@@ -20,7 +20,11 @@ void main() {
     providerAccountEmail: 'test@syncademic.io',
   );
 
-  const status = SyncProfileStatus.notStarted();
+  final updatedAt = DateTime(2024, 1, 1);
+
+  final status = SyncProfileStatus.notStarted(
+    updatedAt: updatedAt,
+  );
 
   test('should create a SyncProfile instance', () {
     final syncProfile = SyncProfile(
@@ -143,7 +147,9 @@ void main() {
 
     test('should not be equal to another SyncProfile with a different status',
         () {
-      const status1 = SyncProfileStatus.failed('Error message');
+      final status1 =
+          SyncProfileStatus.failed('Error message', updatedAt: updatedAt);
+
       final syncProfile1 = SyncProfile(
         id: id,
         title: title,

--- a/syncademic_app/test/screens/sync_profile/cubit/sync_profile_state_test.dart
+++ b/syncademic_app/test/screens/sync_profile/cubit/sync_profile_state_test.dart
@@ -8,13 +8,14 @@ import 'package:syncademic_app/screens/sync_profile/cubit/sync_profile_cubit.dar
 
 const scheduleSource1 = ScheduleSource(url: "https://example.com");
 final targetCalendar1 = TargetCalendar(
-  id: ID(),
-  title: "Calendar 1",
-  description: "Description 1",
-  providerAccountId: "6371892",
-  createdBySyncademic: true,
-  providerAccountEmail: 'test@syncademic.io'
-);
+    id: ID(),
+    title: "Calendar 1",
+    description: "Description 1",
+    providerAccountId: "6371892",
+    createdBySyncademic: true,
+    providerAccountEmail: 'test@syncademic.io');
+
+final updatedAt = DateTime(2024, 1, 1);
 
 SyncProfile getSyncProfile({
   required SyncProfileStatus status,
@@ -35,7 +36,9 @@ void main() {
   group('canRequestSync', () {
     test('sync already in progress', () {
       final syncProfile = getSyncProfile(
-        status: const SyncProfileStatus.inProgress(),
+        status: SyncProfileStatus.inProgress(
+          updatedAt: updatedAt,
+        ),
       );
       final state = SyncProfileState.loaded(syncProfile);
 
@@ -44,7 +47,9 @@ void main() {
 
     test('last sync request was less than kMinSyncInterval ago', () {
       final syncProfile = getSyncProfile(
-        status: const SyncProfileStatus.success(),
+        status:  SyncProfileStatus.success(
+          updatedAt: updatedAt,
+        ),
       );
       final state =
           SyncProfileState.loaded(syncProfile, lastSyncRequest: DateTime.now());
@@ -54,7 +59,9 @@ void main() {
 
     test('last sync request was more than kMinSyncInterval ago', () {
       final syncProfile = getSyncProfile(
-        status: const SyncProfileStatus.success(),
+        status: SyncProfileStatus.success(
+          updatedAt: updatedAt,
+        ),
       );
       final state = SyncProfileState.loaded(
         syncProfile,


### PR DESCRIPTION
Previously, the lastSuccessfulSync was stored in syncProfile.status. The value was even erased on status updated. Since it's not really related to the status, but rather the syncProfile itself, we move this property back to the syncProfile.

We also add an `updatedAt` property to syncProfile.status, and display it in the UI. 