### PR TITLE
Fix all day bug

### DIFF
--- a/functions/functions/shared/event.py
+++ b/functions/functions/shared/event.py
@@ -13,6 +13,7 @@ class Event:
     description: str = ""
     location: str = ""
     color: GoogleEventColor | None = None
+    is_all_day: bool = False
 
     def __post_init__(self):
         if self.start is None or self.end is None:

--- a/functions/functions/synchronizer/google_calendar_manager.py
+++ b/functions/functions/synchronizer/google_calendar_manager.py
@@ -46,15 +46,22 @@ class GoogleCalendarManager:
     def _event_to_google_event(
         event: Event, extended_properties: ExtendedProperties
     ) -> dict:
-        # Format the start and end times to RFC 3339
-        start_time_rfc3339 = event.start.format("YYYY-MM-DDTHH:mm:ssZZ")
-        end_time_rfc3339 = event.end.format("YYYY-MM-DDTHH:mm:ssZZ")
+        if event.is_all_day:
+            start = {"date": event.start.strftime("%Y-%m-%d")}
+            end = {"date": event.end.strftime("%Y-%m-%d")}
+        else:
+            # Format the start and end times to RFC 3339
+            start_time_rfc3339 = event.start.format("YYYY-MM-DDTHH:mm:ssZZ")
+            end_time_rfc3339 = event.end.format("YYYY-MM-DDTHH:mm:ssZZ")
+
+            start = {"dateTime": start_time_rfc3339}
+            end = {"dateTime": end_time_rfc3339}
 
         body = {
             "summary": event.title,
             "description": event.description,
-            "start": {"dateTime": start_time_rfc3339},
-            "end": {"dateTime": end_time_rfc3339},
+            "start": start,
+            "end": end,
             "location": event.location,
             "extendedProperties": extended_properties,
         }

--- a/functions/functions/synchronizer/ics_parser.py
+++ b/functions/functions/synchronizer/ics_parser.py
@@ -101,6 +101,7 @@ class IcsParser:
                         start=event.begin,
                         end=event.end,
                         location=event.location or "",
+                        is_all_day=event.all_day,
                     )
                 )
             except Exception as e:

--- a/functions/tests/synchronizer/google_calendar_manager_test.py
+++ b/functions/tests/synchronizer/google_calendar_manager_test.py
@@ -70,6 +70,27 @@ def test_event_to_google_event_with_color():
     }
 
 
+def test_all_day_event_to_google_event():
+    # Arrange
+    service = Mock()
+    calendar_id = "test_calendar_id"
+    manager = GoogleCalendarManager(service=service, calendar_id=calendar_id)
+
+    event = Event(
+        start=arrow.get("2023-01-01T00:00:00+00:00"),
+        end=arrow.get("2023-01-02T00:00:00+00:00"),
+        title="All Day Event",
+        is_all_day=True,
+    )
+
+    # Act
+    google_event = manager._event_to_google_event(event, {})
+
+    # Assert
+    assert google_event["start"] == {"date": "2023-01-01"}
+    assert google_event["end"] == {"date": "2023-01-02"}
+
+
 def test_get_syncademic_marker():
     # Arrange
     service = Mock()
@@ -145,9 +166,9 @@ def test_create_events_in_batches():
         Event(
             start=arrow.get(f"2023-01-{(i % 31) + 1:02d}T09:00:00+00:00"),
             end=arrow.get(f"2023-01-{(i % 31) + 1:02d}T10:00:00+00:00"),
-            title=f"Event {i+1}",
-            description=f"Description {i+1}",
-            location=f"Location {i+1}",
+            title=f"Event {i + 1}",
+            description=f"Description {i + 1}",
+            location=f"Location {i + 1}",
         )
         for i in range(n_events)
     ]

--- a/functions/tests/synchronizer/ics_parser_test.py
+++ b/functions/tests/synchronizer/ics_parser_test.py
@@ -244,3 +244,26 @@ END:VEVENT"""
 def test_empty_ics_string(ics_parser: IcsParser):
     error = ics_parser.try_parse("")
     assert isinstance(error, IcsParsingError)
+
+
+def test_all_day_event(ics_parser: IcsParser):
+    """Test parsing an all-day event with VALUE=DATE format."""
+    ics_str = build_ics_outline(
+        """BEGIN:VEVENT
+DTSTAMP:20250318T060707Z
+UID:MockUID
+DTSTART;VALUE=DATE:20250609
+DTEND;VALUE=DATE:20250610
+SUMMARY;LANGUAGE=fr:This is an All day event
+END:VEVENT"""
+    )
+    events = ics_parser.try_parse(ics_str)
+
+    assert isinstance(events, list)
+    assert len(events) == 1
+
+    event = events[0]
+    assert event.title == "This is an All day event"
+    assert event.start.format("YYYY-MM-DD") == "2025-06-09"
+    assert event.end.format("YYYY-MM-DD") == "2025-06-10"
+    assert event.is_all_day


### PR DESCRIPTION
# PR: Fix All-Day Events in Google Calendar

## Problem

When syncing all-day events from ICS files (containing `VALUE=DATE`) to Google Calendar, the events were incorrectly appearing as timed events starting at 2AM (in France) rather than true all-day events.

## Root Cause

Google Calendar API has distinct formats for timed vs. all-day events:
- Timed events use: `"start": {"dateTime": "2025-06-09T10:00:00+00:00"}`
- All-day events require: `"start": {"date": "2025-06-09"}`

Our code was treating all events as timed events, even when the original ICS defined them as all-day events.

## Solution

1. Added an `is_all_day` flag to the `Event` dataclass to track all-day status
2. Updated the ICS parser to detect all-day events and set this flag
3. Modified the Google Calendar format conversion to use the correct format:
   - Use `date` format for all-day events
   - Continue using `dateTime` format for timed events
4. Added a test to verify proper parsing and handling of all-day events

This change will fix the issue where events like holidays, full-day appointments, and other all-day events were showing at 2AM instead of spanning the entire day.





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced event handling to support all-day events, ensuring events display correctly whether timed or full-day.
	- Improved calendar integration to properly format dates for all-day events.
- **Tests**
	- Added tests to validate that all-day events are correctly parsed and synchronized.
	- New tests to verify the conversion of all-day events into Google Calendar event format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->