### PR TITLE
Fix recurrence event detection

### DIFF
--- a/backend/backend/synchronizer/ics_parser.py
+++ b/backend/backend/synchronizer/ics_parser.py
@@ -24,7 +24,7 @@ def _is_recurring_event(event: ics.Event) -> bool:
     extra_names: list[str] = [extra.name for extra in event.extra]
     assert all(isinstance(name, str) for name in extra_names)
 
-    recurring_props = ["RRULE", "RDATE", "EXDATE"]
+    recurring_props = ["RRULE", "RDATE", "EXDATE", "RECURRENCE-ID"]
     return any(
         extra_name.startswith(prop)
         for extra_name in extra_names

--- a/backend/tests/synchronizer/ics_parser_test.py
+++ b/backend/tests/synchronizer/ics_parser_test.py
@@ -241,6 +241,20 @@ END:VEVENT"""
     assert isinstance(error, RecurringEventError)
 
 
+def test_recurring_event_with_recurrence_id_throws(ics_parser: IcsParser):
+    """Test that a recurring event with RECURRENCE-ID raises an error."""
+    ics_str = build_ics_outline(
+        """BEGIN:VEVENT
+SUMMARY:Recurring Event
+DTSTART:20230101T090000
+DTEND:20230101T100000
+RECURRENCE-ID:20230102T090000
+END:VEVENT"""
+    )
+    error = ics_parser.try_parse(ics_str)
+    assert isinstance(error, RecurringEventError)
+
+
 def test_empty_ics_string(ics_parser: IcsParser):
     error = ics_parser.try_parse("")
     assert isinstance(error, IcsParsingError)


### PR DESCRIPTION
## Summary
- detect `RECURRENCE-ID` field when checking recurring events
- test `RECURRENCE-ID` detection in `IcsParser`

## Testing
- `uv run pytest tests/synchronizer/ics_parser_test.py::test_recurring_event_with_recurrence_id_throws -q`
- `uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f6f28043c8328b771a9127ab7645f