### PR TITLE
Fix admin sync profiles help text

### DIFF
--- a/admin/src/admin/pages/sync_profiles.py
+++ b/admin/src/admin/pages/sync_profiles.py
@@ -119,7 +119,7 @@ with st.sidebar:
     # Error filter
     error_filter = st.checkbox(
         "Show Only Profiles with Errors",
-        help="Show only profiles that have errors (Satus failed), or Ruleset geneartion error.",
+        help="Show only profiles that have errors (Status failed), or Ruleset generation error.",
     )
 
 # Fetch data


### PR DESCRIPTION
## Summary
- fix typo in error filter checkbox help string

## Testing
- `../backend/.venv/bin/python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f70776c7c83288c724103bd3a2ba2