### PR TITLE
Replace deprecated logger.warn usage

### DIFF
--- a/backend/backend/services/dev_notification_service.py
+++ b/backend/backend/services/dev_notification_service.py
@@ -136,7 +136,7 @@ class TelegramDevNotificationService(IDevNotificationService):
 
         try:
             if not (user := self.user_service.get_user(user_id)):
-                logger.warn(
+                logger.warning(
                     f"User not found: {user_id}",
                     user_id=user_id,
                 )
@@ -146,7 +146,7 @@ class TelegramDevNotificationService(IDevNotificationService):
                 "email": user.email,
             }
         except Exception as e:
-            logger.warn(
+            logger.warning(
                 f"Error getting user display name: {type(e).__name__}: {str(e)}",
                 user_id=user_id,
             )
@@ -169,9 +169,11 @@ class TelegramDevNotificationService(IDevNotificationService):
             response = requests.post(self.api_url, json=payload, timeout=5.0)
 
             if not response.ok:
-                logger.warn(f"Failed to send Telegram notification: {response.text}")
+                logger.warning(
+                    f"Failed to send Telegram notification: {response.text}"
+                )
         except Exception as e:
-            logger.warn(f"Error sending Telegram notification: {str(e)}")
+            logger.warning(f"Error sending Telegram notification: {str(e)}")
 
     def on_new_user(self, domain_event: domain_events.UserCreated) -> None:
         message = (
@@ -296,7 +298,7 @@ def create_dev_notification_service(
 ) -> IDevNotificationService:
     """Factory function to create the appropriate notification service based on settings."""
     if not settings.TELEGRAM_BOT_TOKEN or not settings.TELEGRAM_CHAT_ID:
-        logger.warn("Telegram credentials not configured")
+        logger.warning("Telegram credentials not configured")
         return NoOpDevNotificationService()
 
     return TelegramDevNotificationService(

--- a/backend/backend/services/google_calendar_service.py
+++ b/backend/backend/services/google_calendar_service.py
@@ -40,7 +40,7 @@ class GoogleCalendarService:
                 calendars.extend(calendars_result.get("items", []))
                 if len(calendars) >= max_calendars:
                     calendars = calendars[:max_calendars]
-                    logger.warn(
+                    logger.warning(
                         "Max calendars reached while listing calendars",
                         user_id=user_id,
                         provider_account_id=provider_account_id,
@@ -129,7 +129,7 @@ class GoogleCalendarService:
         except HttpError as e:
             # Check if the error is specifically a 404 Not Found
             if e.resp.status == 404:
-                logger.warn(
+                logger.warning(
                     f"Calendar not found (404) for ID: {calendar_id}",
                     user_id=user_id,
                     provider_account_id=provider_account_id,

--- a/backend/backend/services/sync_profile_service.py
+++ b/backend/backend/services/sync_profile_service.py
@@ -244,7 +244,7 @@ class SyncProfileService:
                 raise e
 
         if not events:
-            logger.warn("No events to synchronize")
+            logger.warning("No events to synchronize")
             return
 
         # When it's the first sync, we create all the events on the target calendar

--- a/backend/main.py
+++ b/backend/main.py
@@ -385,7 +385,7 @@ def on_user_created(event: Event[DocumentSnapshot]) -> None:
         }
     except Exception as e:
         # If we can't get Firebase Auth user, just use document data
-        logger.warn(
+        logger.warning(
             f"Could not get Firebase Auth user: {str(e)}",
             user_id=user_id,
             error_type=type(e).__name__,


### PR DESCRIPTION
## Summary
- replace deprecated `logger.warn` calls with `logger.warning` throughout the backend
- ensure warning messages flow through the standard logging API

## Testing
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68c945a1f4608328b50dcb46b21733dd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Standardized logging by replacing deprecated warning calls across backend services.
  * Enhanced a calendar limit warning with threshold details.
  * No behavior or API changes; no user-facing impact.

* Refactor
  * Unified warning level usage for consistency across modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->