### PR TITLE
fix: prevent multiple submissions in NewSyncProfileCubit

### DIFF
--- a/syncademic_app/lib/screens/new_sync_profile/cubit/new_sync_profile_cubit.dart
+++ b/syncademic_app/lib/screens/new_sync_profile/cubit/new_sync_profile_cubit.dart
@@ -242,15 +242,16 @@ class NewSyncProfileCubit extends Cubit<NewSyncProfileState> {
       return;
     }
 
+    emit(state.copyWith(isSubmitting: true));
+
     if (!state.canSubmit()) {
-      return emit(state.copyWith(
+      emit(state.copyWith(
+        isSubmitting: false,
         submitError:
             'Cannot submit invalid form. Please check each step again. If the issue persists, please contact support.',
-        isSubmitting: false,
       ));
+      return;
     }
-
-    emit(state.copyWith(isSubmitting: true));
 
     final scheduleSource = ScheduleSource(
       url: state.url,

--- a/syncademic_app/lib/screens/new_sync_profile/cubit/new_sync_profile_cubit.dart
+++ b/syncademic_app/lib/screens/new_sync_profile/cubit/new_sync_profile_cubit.dart
@@ -238,6 +238,10 @@ class NewSyncProfileCubit extends Cubit<NewSyncProfileState> {
   }
 
   Future<void> submit() async {
+    if (state.isSubmitting) {
+      return;
+    }
+
     if (!state.canSubmit()) {
       return emit(state.copyWith(
         submitError:

--- a/syncademic_app/pubspec.yaml
+++ b/syncademic_app/pubspec.yaml
@@ -17,7 +17,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.2.2
+version: 0.2.3
 
 environment:
   sdk: ">=3.2.6 <4.0.0"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented concurrent submit actions in the new sync profile flow. Additional taps while a submission is in progress are ignored, avoiding duplicate requests, inconsistent states, and unexpected errors for a more stable submission experience.

* **Chores**
  * Bumped app version to 0.2.3 to reflect these fixes and improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->